### PR TITLE
Change strategy of retrieving sessions

### DIFF
--- a/src/repository/DefaultSessionRepository.ts
+++ b/src/repository/DefaultSessionRepository.ts
@@ -33,8 +33,8 @@ class DefaultSessionRepository implements ISessionRepository {
   public getSessionsObservable(filter: SessionFilter): Observable<Session[]> {
     return new Observable(subscriber => {
       let query: firestore.Query = firebase
-      .firestore()
-      .collection("sessions");
+        .firestore()
+        .collection("sessions");
       if (filter.conferenceId !== undefined) {
         query = query.where("conferenceId", "==", filter.conferenceId);
       }
@@ -43,18 +43,31 @@ class DefaultSessionRepository implements ISessionRepository {
       }
       query = query
         .orderBy("starts", "asc")
-        .limit(200);
+        .limit(100);
 
-      const canceller = query
-        .onSnapshot(snapshot => {
-          const requests = snapshot.docs.map((doc) => Session.fromSnapshot(doc));
-          subscriber.next(requests);
-        }, error => {
+      let isUnsubscribed = false;
+      (async () => {
+        try {
+          let sessions: Session[] = [];
+          let snapshot = await query.get();
+          while (!isUnsubscribed && snapshot.size > 0) {
+            sessions = sessions.concat(snapshot.docs.map(doc => Session.fromSnapshot(doc)));
+            subscriber.next(sessions);
+            await new Promise(resolve => setTimeout(resolve, 100));
+            if (!isUnsubscribed) {
+              snapshot = await query
+                .startAfter(snapshot.docs[snapshot.docs.length - 1])
+                .get();
+            }
+          }
+        } catch (error) {
           subscriber.error(error);
-        });
-
-      return canceller;
-    });    
+        }
+      })();
+      return () => {
+        isUnsubscribed = true;
+      };
+    });
   }
 
   public getSessionObservable(sessionId: string): Observable<Session> {

--- a/src/repository/DefaultSessionRepository.ts
+++ b/src/repository/DefaultSessionRepository.ts
@@ -60,6 +60,7 @@ class DefaultSessionRepository implements ISessionRepository {
                 .get();
             }
           }
+          subscriber.complete();
         } catch (error) {
           subscriber.error(error);
         }


### PR DESCRIPTION
## TL;DR
- Before this PR, the sessions in the search result is "live", but its count is limited up to 200
- After this PR, the sessions in the search result is not "live", but it eventually shows sessions with unlimited count

## Detailed description

### Before this PR
The returned observable emits the whole sessions that matches the filter (with limited count 200) one time. And the session data is changed in database,  it emits the whole matched sessions again.
The observable doesn't complete.
```
                             data changes
database   ----------------------o-----------------------

observable -----o-----------------o-----------------------
         up to 200 sessions    up to 200 sessions
         matches the filter    matches the filter
```

### After this PR
The returned observable first emits up to 100 sessions that matches the filter. And when any more sessions exist in database, it re-emits the data with more 100 sessions (up to 200 sessions totally).
Repeating it until all matched sessions are emitted, then it completes.
Even if the session data is changed in database, the observable doesn't emit the data again.
```
observable -----o--------------o--------------------o-----------------------|
         up to 100 sessions   up to 200 sessions   up to 300 sessions     completes after
         matches the filter   matches the filter   matches the filter     all sessions
                                                                          are retrieved
```

```
                             data changes
database   ----------------------o-----------------------

observable -----o-----o--|       ignored because it was completed
```

```
                             data changes
database   ----------------------o-----------------------

observable -----o----------o----------o----------------|      
              1-100      1-200      1-300
                                  changes in the session 1-200 are ignored
                                  changes in the session 201-300 are reflected
```