### PR TITLE
Do not complete the observable

### DIFF
--- a/src/repository/DefaultSessionRepository.ts
+++ b/src/repository/DefaultSessionRepository.ts
@@ -53,7 +53,6 @@ class DefaultSessionRepository implements ISessionRepository {
 
           if (snapshot.size <= 0) {
             subscriber.next([]);
-            subscriber.complete();
           } else {
             let sessions: Session[] = [];
             do {
@@ -67,7 +66,6 @@ class DefaultSessionRepository implements ISessionRepository {
                 .get();
               if (isUnsubscribed) { return; }
             } while (snapshot.size > 0);
-            subscriber.complete();
           }
         } catch (error) {
           subscriber.error(error);


### PR DESCRIPTION
Even though we had changed the search session strategy in #3, I noticed that it was a bad idea to complete observable.
In whole design, observables returned from a repository is considered as infinite observable by our BLoCs.

After merging this PR, the observable returned from `getSessionsObservable()` becomes infinite observable again.

```
observable -----o--------------o--------------------o------------------
         up to 100 sessions   up to 200 sessions   up to 300 sessions
         match the filter     match the filter     match the filter
```

```
                             data changes
database   ----------------------o-----------------------

observable -----o-----o-------------- changes are ignored
```

```
                             data changes
database   ----------------------o-----------------------

observable -----o----------o----------o------------------      
              1-100      1-200      1-300
                                  changes in the session 1-200 are ignored
                                  changes in the session 201-300 are reflected
```