### PR TITLE
Filter sessions by keywords

### DIFF
--- a/src/common/CaseInsensitiveSearch.ts
+++ b/src/common/CaseInsensitiveSearch.ts
@@ -1,0 +1,56 @@
+//
+// CaseInsensitiveSearch.ts
+//
+// Copyright (c) 2019 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+export interface ICaseInsensitiveSearchResult {
+  index: number;
+  length: number;
+}
+
+export default class CaseInsensitiveSearch {
+  public str: string;
+  private regExp: RegExp;
+
+  constructor(str: string) {
+    this.str = str;
+    this.regExp = new RegExp(str.replace(/[-[\]{}()*+?.,\\^$|#\s]/, "\\$&"), "ig");
+  }
+
+  public foundIn(text: string): boolean {
+    this.regExp.lastIndex = 0;
+    return this.regExp.test(text);
+  }
+
+  public searchIn(text: string, position: number): ICaseInsensitiveSearchResult | null {
+    this.regExp.lastIndex = position;
+    const match = this.regExp.exec(text);
+    if (match !== null) {
+      return {
+        index: match.index,
+        length: match[0].length,
+      };
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/repository/DefaultSessionRepository.ts
+++ b/src/repository/DefaultSessionRepository.ts
@@ -30,7 +30,6 @@ import SessionFilter from './SessionFilter';
 import { ISessionRepository } from './SessionRepository';
 
 function isTextContainsKeyword(text: string, keyword: string) {
-  // FIXME: consider line break
   return text.indexOf(keyword) >= 0;
 }
 

--- a/src/repository/DefaultSessionRepository.ts
+++ b/src/repository/DefaultSessionRepository.ts
@@ -29,6 +29,43 @@ import Session from 'src/model/Session';
 import SessionFilter from './SessionFilter';
 import { ISessionRepository } from './SessionRepository';
 
+function isTextContainsKeyword(text: string, keyword: string) {
+  // FIXME: consider line break
+  return text.indexOf(keyword) >= 0;
+}
+
+function filterByKeywords(keywords?: string[]): (session: Session) => boolean {
+  if (keywords === undefined) {
+    return session => true;
+  }
+
+  return session => {
+    for (const keyword of keywords) {
+      if (isTextContainsKeyword(session.title, keyword)) {
+        return true;
+      }
+
+      if (isTextContainsKeyword(session.description, keyword)) {
+        return true;
+      }
+
+      for (const speaker of session.speakers) {
+        if (isTextContainsKeyword(speaker.name, keyword)) {
+          return true;
+        }
+        if (speaker.twitter !== undefined) {
+          if (isTextContainsKeyword(speaker.twitter, keyword)) {
+            return true;
+          }
+        }
+      }
+    }
+
+    return false;
+  };
+}
+
+
 class DefaultSessionRepository implements ISessionRepository {
   public getSessionsObservable(filter: SessionFilter): Observable<Session[]> {
     return new Observable(subscriber => {
@@ -56,7 +93,11 @@ class DefaultSessionRepository implements ISessionRepository {
           } else {
             let sessions: Session[] = [];
             do {
-              sessions = sessions.concat(snapshot.docs.map(doc => Session.fromSnapshot(doc)));
+              sessions = sessions.concat(
+                snapshot.docs
+                  .map(doc => Session.fromSnapshot(doc))
+                  .filter(filterByKeywords(filter.keywords))
+              );
               subscriber.next(sessions);
               await new Promise(resolve => setTimeout(resolve, 100));
               if (isUnsubscribed) { return; }

--- a/src/repository/DefaultSessionRepository.ts
+++ b/src/repository/DefaultSessionRepository.ts
@@ -98,7 +98,9 @@ class DefaultSessionRepository implements ISessionRepository {
                   .map(doc => Session.fromSnapshot(doc))
                   .filter(filterByKeywords(filter.keywords))
               );
-              subscriber.next(sessions);
+              if (sessions.length > 0) {
+                subscriber.next(sessions);
+              }
               await new Promise(resolve => setTimeout(resolve, 100));
               if (isUnsubscribed) { return; }
     
@@ -107,6 +109,9 @@ class DefaultSessionRepository implements ISessionRepository {
                 .get();
               if (isUnsubscribed) { return; }
             } while (snapshot.size > 0);
+            if (sessions.length === 0) {
+              subscriber.next([]);
+            }
           }
         } catch (error) {
           subscriber.error(error);

--- a/src/repository/DefaultSessionRepository.ts
+++ b/src/repository/DefaultSessionRepository.ts
@@ -25,13 +25,10 @@
 import firebase, { firestore } from "firebase/app";
 import "firebase/firestore";
 import { Observable } from 'rxjs';
+import CaseInsensitiveSearch from 'src/common/CaseInsensitiveSearch';
 import Session from 'src/model/Session';
 import SessionFilter from './SessionFilter';
 import { ISessionRepository } from './SessionRepository';
-
-function isTextContainsKeyword(text: string, keyword: string) {
-  return text.indexOf(keyword) >= 0;
-}
 
 function filterByKeywords(keywords?: string[]): (session: Session) => boolean {
   if (keywords === undefined) {
@@ -40,20 +37,22 @@ function filterByKeywords(keywords?: string[]): (session: Session) => boolean {
 
   return session => {
     for (const keyword of keywords) {
-      if (isTextContainsKeyword(session.title, keyword)) {
+      const searcher = new CaseInsensitiveSearch(keyword);
+      
+      if (searcher.foundIn(session.title)) {
         return true;
       }
 
-      if (isTextContainsKeyword(session.description, keyword)) {
+      if (searcher.foundIn(session.description)) {
         return true;
       }
 
       for (const speaker of session.speakers) {
-        if (isTextContainsKeyword(speaker.name, keyword)) {
+        if (searcher.foundIn(speaker.name)) {
           return true;
         }
         if (speaker.twitter !== undefined) {
-          if (isTextContainsKeyword(speaker.twitter, keyword)) {
+          if (searcher.foundIn(speaker.twitter)) {
             return true;
           }
         }

--- a/src/repository/SessionFilter.ts
+++ b/src/repository/SessionFilter.ts
@@ -25,18 +25,22 @@
 interface ISessionFilter {
   conferenceId?: string;
   minutes?: number;
+  keywords?: string[];
 }
 
 class SessionFilter implements ISessionFilter {
   public conferenceId?: string;
   public minutes?: number;
+  public keywords?: string[];
 
   public constructor({
     conferenceId,
     minutes,
+    keywords,
   }: ISessionFilter) {
     this.conferenceId = conferenceId;
     this.minutes = minutes;
+    this.keywords = keywords;
   }
 }
 

--- a/src/view/video/DefaultVideoBloc.test.ts
+++ b/src/view/video/DefaultVideoBloc.test.ts
@@ -216,6 +216,35 @@ it("changes selection of session time filter by user's operation", async () => {
   await expectation2;
 });
 
+it("initially shows empty keywords filter", async () => {
+  createBloc();
+
+  const observer = new EventuallyObserver<string>();
+  const expectation = observer.expectValue(filterKeywords => {
+    expect(filterKeywords).toBe("");
+  });
+  subscription.add(bloc.filterKeywords.subscribe(observer));
+  await expectation;
+});
+
+it("changes the keywords filter by user's input", async () => {
+  createBloc();
+
+  const observer = new EventuallyObserver<string>();
+  const expectation1 = observer.expectValue(filterKeywords => {
+    expect(filterKeywords).toBe("foo");
+  });
+  subscription.add(bloc.filterKeywords.subscribe(observer));
+  bloc.filterKeywordsChanged.next("foo");
+  await expectation1;
+
+  const expectation2 = observer.expectValue(filterKeywords => {
+    expect(filterKeywords).toBe("foo bar");
+  });
+  bloc.filterKeywordsChanged.next("foo bar");
+  await expectation2;
+});
+
 it("initially has session list which is not loaded yet", async () => {
   createBloc();
 
@@ -285,6 +314,7 @@ it("passes the filter setting to the repository", async () => {
 
   bloc.filterConferenceChanged.next("c2");
   bloc.filterSessionTimeChanged.next("30");
+  bloc.filterKeywordsChanged.next("key word");
 
   const sessionListObserver = new EventuallyObserver<ISessionList>();
   const expectationOfLoading = sessionListObserver.expectValue(sessionList => {
@@ -297,6 +327,7 @@ it("passes the filter setting to the repository", async () => {
   expect(mockSessionRepository.getSessionsObservable).toHaveBeenCalledWith(new SessionFilter({
     conferenceId: "c2",
     minutes: 30,
+    keywords: ["key", "word"],
   }));
 });
 

--- a/src/view/video/DefaultVideoBloc.ts
+++ b/src/view/video/DefaultVideoBloc.ts
@@ -153,7 +153,7 @@ class DefaultVideoBloc implements IVideoBloc {
       map(([conf, min, keywords]) => new SessionFilter({
         conferenceId: (conf === '-') ? undefined : conf,
         minutes: (min === '-') ? undefined : parseInt(min, 10),
-        keywords: (keywords.trim() === "") ? undefined : keywords.trim().split(/ +/),
+        keywords: (keywords.trim() === "") ? undefined : keywords.trim().split(/\s+/),
       })),
     );
 

--- a/src/view/video/DefaultVideoBloc.ts
+++ b/src/view/video/DefaultVideoBloc.ts
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 //
 
-import { combineLatest, ConnectableObservable, merge, never, Observable, Observer, Subject, Subscription } from "rxjs";
+import { BehaviorSubject, combineLatest, ConnectableObservable, merge, never, Observable, Observer, Subject, Subscription } from "rxjs";
 import { catchError, distinctUntilChanged, map, publishBehavior, shareReplay, startWith, switchMap, withLatestFrom } from 'rxjs/operators';
 import DropdownState from 'src/common/DropdownState';
 import DropdownStateItem from 'src/common/DropdownStateItem';
@@ -46,6 +46,7 @@ class DefaultVideoBloc implements IVideoBloc {
     const expandFilterPanel = new Subject<boolean>();
     const filterConferenceChanged = new Subject<string>();
     const filterSessionTimeChanged = new Subject<string>();
+    const filterKeywords = new BehaviorSubject<string>("");
     const executeFilter = new Subject<void>();
 
     const isFilterPanelExpanded = merge(
@@ -144,13 +145,15 @@ class DefaultVideoBloc implements IVideoBloc {
     const currentFilters = combineLatest(
       currentConferenceFilter,
       currentSessionTimeFilter,
+      filterKeywords,
     );
 
     const sessionFilter = executeFilter.pipe(
       withLatestFrom(currentFilters, (e, v) => v),
-      map(([conf, min]) => new SessionFilter({
+      map(([conf, min, keywords]) => new SessionFilter({
         conferenceId: (conf === '-') ? undefined : conf,
         minutes: (min === '-') ? undefined : parseInt(min, 10),
+        keywords: (keywords.trim() === "") ? undefined : keywords.trim().split(/ +/),
       })),
     );
 
@@ -224,10 +227,12 @@ class DefaultVideoBloc implements IVideoBloc {
       expandFilterPanel,
       filterConferenceChanged,
       filterSessionTimeChanged,
+      filterKeywords,
       executeFilter,
       isFilterPanelExpanded,
       filterConference,
       filterSessionTime,
+      filterKeywords,
       sessionListState,
     )
   }
@@ -239,12 +244,15 @@ class DefaultVideoBloc implements IVideoBloc {
     public expandFilterPanel: Observer<boolean>,
     public filterConferenceChanged: Observer<string>,
     public filterSessionTimeChanged: Observer<string>,
+    public filterKeywordsChanged: Observer<string>,
+
     public executeFilter: Observer<void>,
 
     // outputs
     public isFilterPanelExpanded: Observable<boolean>,
     public filterConference: Observable<DropdownState>,
     public filterSessionTime: Observable<DropdownState>,
+    public filterKeywords: Observable<string>,
     public sessionList: Observable<ISessionList>,
   ) {}
 

--- a/src/view/video/DefaultVideoBloc.ts
+++ b/src/view/video/DefaultVideoBloc.ts
@@ -200,7 +200,8 @@ class DefaultVideoBloc implements IVideoBloc {
       ).pipe(
         map(({sessions, events, conferenceNameMap}) => ({
           state: SessionListState.Loaded,
-          sessions: sessions.map<ISessionItem>(convertSession(conferenceNameMap, events))
+          sessions: sessions.map<ISessionItem>(convertSession(conferenceNameMap, events)),
+          keywordList: (filter.keywords !== undefined) ? filter.keywords : [],
         } as ISessionList)),
         startWith({
           state: SessionListState.Loading,          

--- a/src/view/video/SessionList.tsx
+++ b/src/view/video/SessionList.tsx
@@ -25,6 +25,7 @@
 import { Avatar, Card, CardActionArea, CircularProgress, Grid, StyledComponentProps, Theme, Typography, withStyles } from '@material-ui/core';
 import CheckIcon from '@material-ui/icons/Check';
 import React, { Fragment } from 'react';
+import CaseInsensitiveSearch from 'src/common/CaseInsensitiveSearch';
 import Snapshot from 'src/common/Snapshot';
 import Speaker from 'src/model/Speaker';
 import SessionDetailContext from '../session_detail/SessionDetailContext';
@@ -294,12 +295,13 @@ class SessionList extends React.Component<StyledComponentProps> {
     let searchOffset = 0;
     let nextRange: IBoldRange | null;
     const boldRanges: IBoldRange[] = [];
+    const searchList = keywordList.map(keyword => new CaseInsensitiveSearch(keyword));
     do {
       // assume that keywordList is sorted in order from longest to shortest
-      nextRange = keywordList.reduce((acc, keyword) => {
-        const offset = line.indexOf(keyword, searchOffset);
-        if (offset >= 0 && (acc === null || offset < acc.offset)) {
-          return {offset, length: keyword.length};
+      nextRange = searchList.reduce((acc, search) => {
+        const searchResult = search.searchIn(line, searchOffset);
+        if (searchResult !== null && (acc === null || searchResult.index < acc.offset)) {
+          return {offset: searchResult.index, length: searchResult.length};
         } else {
           return acc;
         }

--- a/src/view/video/SessionList.tsx
+++ b/src/view/video/SessionList.tsx
@@ -228,7 +228,7 @@ class SessionList extends React.Component<StyledComponentProps> {
 
         let lwbr = lineWithBoldRanges[lineIndex];
         if (lineIndex === firstKeywordLine) {
-          if (lwbr.boldRanges[0].offset >= maxChars) {
+          if (lwbr.boldRanges[0].offset > maxChars / 2) {
             const beginOffset = lwbr.boldRanges[0].offset - Math.floor(maxChars / 2);
             const beginOffset2 = beginOffset - "…".length;
             lwbr = {

--- a/src/view/video/SessionSearchFilter.tsx
+++ b/src/view/video/SessionSearchFilter.tsx
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 //
 
-import { Button, Card, CardActions, CardContent, Collapse, FormControl, Grid, IconButton, InputLabel, MenuItem, Select, Typography } from '@material-ui/core';
+import { Button, Card, CardActions, CardContent, Collapse, FormControl, Grid, IconButton, InputLabel, MenuItem, Select, TextField, Typography } from '@material-ui/core';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import React from 'react';
@@ -107,6 +107,30 @@ class SessionSearchFilter extends React.Component {
                                   </Select>
                                 </FormControl>
                               )}
+                            </Snapshot>
+                          </Grid>
+                          <Grid item={true} xs={12} style={{textAlign: "start"}}>
+                            <Snapshot source={bloc.filterKeywords} initialValue="">
+                              {(value: string) => {
+                                const onChange: React.ChangeEventHandler<HTMLInputElement> = event => {
+                                  bloc.filterKeywordsChanged.next(event.target.value);
+                                };
+                                return (
+                                  <TextField
+                                    type="text"
+                                    autoFocus={false}
+                                    label="キーワード"
+                                    placeholder="スペースで区切って指定"
+                                    margin="none"
+                                    fullWidth={true}
+                                    onChange={onChange}
+                                    value={value}
+                                    InputLabelProps={{
+                                      shrink: true,
+                                    }}
+                                  />
+                                );
+                              }}
                             </Snapshot>
                           </Grid>
                         </Grid>

--- a/src/view/video/VideoBloc.ts
+++ b/src/view/video/VideoBloc.ts
@@ -70,11 +70,13 @@ export interface IVideoBloc extends IBloc {
   expandFilterPanel: Observer<boolean>;
   filterConferenceChanged: Observer<string>;
   filterSessionTimeChanged: Observer<string>;
+  filterKeywordsChanged: Observer<string>;
   executeFilter: Observer<void>;
 
   // outputs
   isFilterPanelExpanded: Observable<boolean>;
   filterConference: Observable<DropdownState>;
   filterSessionTime: Observable<DropdownState>;
+  filterKeywords: Observable<string>;
   sessionList: Observable<ISessionList>;
 }

--- a/src/view/video/VideoBloc.ts
+++ b/src/view/video/VideoBloc.ts
@@ -56,6 +56,7 @@ export interface ISessionListLoading {
 export interface ISessionListLoaded {
   state: SessionListState.Loaded;
   sessions: ISessionItem[];
+  keywordList: string[];
 }
 
 export interface ISessionListError {


### PR DESCRIPTION
On "動画を見つける" ("Find Movie") page, filtering sessions by user specified keywords would be useful.

- [x] `DefaultSessionRepository`: Make it possible to filter by keywords
- [x] `DefaultVideoBloc`: Add keywords filter as input and pass it to the repository
- [x] `SessionSearchFilter`: Build keywords on its UI
- [x] Make matched words in description visible