### PR TITLE
Search video sessions

### DIFF
--- a/src/entities/Session.ts
+++ b/src/entities/Session.ts
@@ -44,7 +44,7 @@ export interface Speaker {
   icon: string | undefined;
 }
 
-interface WatchedOn {
+export interface WatchedOn {
   [eventId: string]: number;
 }
 

--- a/src/features/session/SessionLogic.test.ts
+++ b/src/features/session/SessionLogic.test.ts
@@ -22,19 +22,31 @@
 // THE SOFTWARE.
 //
 
-import { SessionFilter, SessionRepository } from "./SessionRepository";
-import { NEVER, Observable, startWith, Subscription, throwError } from "rxjs";
-// import { Event } from "../../entities/Event";
+import { FilteredSessions, SessionFilter, SessionRepository } from "./SessionRepository";
+import { NEVER, startWith, Subscription, throwError } from "rxjs";
+import { Event } from "../../entities/Event";
 import { Conference } from "../../entities/Conference";
-// import { Session } from "../../entities/Session";
-import { AppSessionLogic, SessionLogic } from "./SessionLogic";
+import { Session } from "../../entities/Session";
+import {
+  AppSessionLogic,
+  MoreRequest,
+  MoreRequestTypes,
+  SessionItem,
+  SessionListDoneProp,
+  SessionListErrorProp,
+  SessionListIRDE,
+  SessionLogic
+} from "./SessionLogic";
 import { EventuallyObserver } from "../../utils/EventuallyObserver";
 import { DropdownState } from "../../utils/Dropdown";
+import { IRDEDone, IRDEError, IRDETypes } from "../../utils/IRDE";
+import { errorMessage } from "../../utils/ErrorMessage";
+import { delay } from "../../utils/Delay";
 
 class MockSessionRepository implements SessionRepository {
-  getAllConferences$ = jest.fn(() => NEVER as Observable<Conference[]>);
-  getAllEvents = jest.fn(async () => []);
-  getSessions = jest.fn(async (_: SessionFilter) => ({ sessions: [], more: undefined }));
+  getAllConferences$ = jest.fn(() => NEVER.pipe(startWith(conferences1)));
+  getAllEvents = jest.fn(async () => events1);
+  getSessions = jest.fn(async (_: SessionFilter) => ({ sessions: sessions1, more: undefined } as FilteredSessions));
 }
 
 const conferences1: Conference[] = [
@@ -43,45 +55,63 @@ const conferences1: Conference[] = [
   { id: "c3", name: "Conf 3", starts: new Date(Date.UTC(2018, 7, 30, 9, 0)) },
 ];
 
-// const sessions1: Session[] = [
-//   {
-//     id: "s1",
-//     conferenceId: "c1",
-//     watched: true,
-//     watchedOn: {"e1": 1, "e3": 2},
-//     title: "Session 1",
-//     description: "",
-//     starts: new Date(Date.UTC(2018, 7, 30, 11, 0)),
-//     minutes: 30,
-//     slide: "https://example.com/slide1",
-//     video: "https://example.com/video1",
-//     speakers: [
-//       { name: "Speaker 1", twitter: "speaker1", icon: undefined }
-//     ]
-//   },
-//   {
-//     id: "s2",
-//     conferenceId: "c2",
-//     watched: false,
-//     watchedOn: {},
-//     title: "Session 2",
-//     description: "",
-//     starts: new Date(Date.UTC(2018, 8, 1, 13, 0)),
-//     minutes: 30,
-//     slide: undefined,
-//     video: "https://example.com/video2",
-//     speakers: [
-//       { name: "Speaker 2", twitter: "speaker2", icon: "https://example.com/image2" },
-//       { name: "Speaker 3", twitter: undefined, icon: "https://example.com/image3" },
-//     ]
-//   },
-// ];
-//
-// const events1: Event[] = [
-//   { id: "e3", name: "Event 3", isAccepting: true },
-//   { id: "e2", name: "Event 2", isAccepting: false },
-//   { id: "e1", name: "Event 1", isAccepting: false },
-// ];
+const sessions1: Session[] = [
+  {
+    id: "s1",
+    conferenceId: "c1",
+    watched: true,
+    watchedOn: {"e1": 1, "e3": 2},
+    title: "Session 1",
+    description: "",
+    starts: new Date(Date.UTC(2018, 7, 30, 11, 0)),
+    minutes: 30,
+    slide: "https://example.com/slide1",
+    video: "https://example.com/video1",
+    speakers: [
+      { name: "Speaker 1", twitter: "speaker1", icon: undefined }
+    ]
+  },
+  {
+    id: "s2",
+    conferenceId: "c2",
+    watched: false,
+    watchedOn: {},
+    title: "Session 2",
+    description: "",
+    starts: new Date(Date.UTC(2018, 8, 1, 13, 0)),
+    minutes: 30,
+    slide: undefined,
+    video: "https://example.com/video2",
+    speakers: [
+      { name: "Speaker 2", twitter: "speaker2", icon: "https://example.com/image2" },
+      { name: "Speaker 3", twitter: undefined, icon: "https://example.com/image3" },
+    ]
+  },
+];
+
+const sessions2: Session[] = [
+  {
+    id: "s3",
+    conferenceId: "c1",
+    watched: false,
+    watchedOn: {},
+    title: "Session 3",
+    description: "",
+    starts: new Date(Date.UTC(2018, 9, 20, 10, 0)),
+    minutes: 15,
+    slide: "https://example.com/slide3",
+    video: "https://example.com/video3",
+    speakers: [
+      { name: "Speaker 4", twitter: undefined, icon: undefined }
+    ],
+  },
+];
+
+const events1: Event[] = [
+  { id: "e3", name: "Event 3", isAccepting: true },
+  { id: "e2", name: "Event 2", isAccepting: false },
+  { id: "e1", name: "Event 1", isAccepting: false },
+];
 
 let mockSessionRepository: MockSessionRepository;
 let subscription: Subscription;
@@ -139,13 +169,50 @@ describe("expand filter panel", () => {
     logic.expandFilterPanel(true);
     await expectation3;
   });
+  
+  it("automatically close when executing filter", async () => {
+    const logic = createLogic();
+
+    const observer = new EventuallyObserver<boolean>();
+    const expectation1 = observer.expectValue(isExpanded => {
+      expect(isExpanded).toBe(true);
+    });
+    subscription.add(logic.isFilterPanelExpanded$.subscribe(observer));
+    await expectation1;
+
+    const expectation2 = observer.expectValue(isExpanded => {
+      expect(isExpanded).toBe(false);
+    });
+    logic.executeFilter({ keywords: "", conference: undefined, sessionTime: undefined }, true);
+    await expectation2;
+  });
+  
+  it("automatically expand when clearing filter", async () => {
+    const logic = createLogic();
+
+    const observer = new EventuallyObserver<boolean>();
+    const expectation1 = observer.expectValue(isExpanded => {
+      expect(isExpanded).toBe(true);
+    });
+    subscription.add(logic.isFilterPanelExpanded$.subscribe(observer));
+    await expectation1;
+
+    const expectation2 = observer.expectValue(isExpanded => {
+      expect(isExpanded).toBe(false);
+    });
+    logic.executeFilter({ keywords: "", conference: undefined, sessionTime: undefined }, true);
+    await expectation2;
+
+    const expectation3 = observer.expectValue(isExpanded => {
+      expect(isExpanded).toBe(true);
+    });
+    logic.clearFilter();
+    await expectation3;
+  });
 });
 
 describe("conference filter", () => {
   it("initially selects 'unspecified'", async () => {
-    mockSessionRepository.getAllConferences$.mockReturnValue(NEVER.pipe(
-      startWith(conferences1),
-    ));
     const logic = createLogic();
     
     const observer = new EventuallyObserver<DropdownState>();
@@ -159,9 +226,6 @@ describe("conference filter", () => {
   });
   
   it("contains conferences", async () => {
-    mockSessionRepository.getAllConferences$.mockReturnValue(NEVER.pipe(
-      startWith(conferences1),
-    ));
     const logic = createLogic();
 
     const observer = new EventuallyObserver<DropdownState>();
@@ -175,9 +239,6 @@ describe("conference filter", () => {
   });
   
   it("changes selection by user's operation", async () => {
-    mockSessionRepository.getAllConferences$.mockReturnValue(NEVER.pipe(
-      startWith(conferences1),
-    ));
     const logic = createLogic();
 
     const observer = new EventuallyObserver<DropdownState>();
@@ -195,7 +256,7 @@ describe("conference filter", () => {
   });
   
   it("shows '<<error>>'", async () => {
-    mockSessionRepository.getAllConferences$.mockReturnValue(throwError(() => new Error("Failed to load conference")));
+    mockSessionRepository.getAllConferences$.mockReturnValue(throwError(() => new Error("Expected fail in loading conference")));
     const logic = createLogic();
 
     const observer = new EventuallyObserver<DropdownState>();
@@ -270,5 +331,220 @@ describe("keywords filter", () => {
     });
     logic.filterKeywordsChanged("foo bar");
     await expectation2;
+  });
+});
+
+describe("session list", () => {
+  it("is initially empty", async () => {
+    const logic = createLogic();
+    
+    const observer = new EventuallyObserver<SessionListIRDE>();
+    const expectation = observer.expectValue(sessionList => {
+      expect(sessionList.type).toBe(IRDETypes.Initial);
+    });
+    subscription.add(logic.sessionList$.subscribe(observer));
+    await expectation;
+    
+    expect(mockSessionRepository.getSessions).not.toHaveBeenCalled();
+  });
+  
+  it("is changed to loading state when filter is executed", async () => {
+    const logic = createLogic();
+
+    const observer = new EventuallyObserver<SessionListIRDE>();
+    const expectation1 = observer.expectValue(sessionList => {
+      expect(sessionList.type).toBe(IRDETypes.Initial);
+    });
+    subscription.add(logic.sessionList$.subscribe(observer));
+    await expectation1;
+
+    const expectation2 = observer.expectValue(sessionList => {
+      expect(sessionList.type).toBe(IRDETypes.Running);
+    });
+    logic.executeFilter({ keywords: "", conference: undefined, sessionTime: undefined }, true);
+    await expectation2;
+  });
+  
+  it("searches sessions from repository", async () => {
+    const logic = createLogic();
+    
+    const observer = new EventuallyObserver<SessionListIRDE>();
+    const expectation = observer.expectValue(sessionList => {
+      expect(sessionList.type).toBe(IRDETypes.Done);
+    });
+    subscription.add(logic.sessionList$.subscribe(observer));
+    
+    logic.executeFilter({ keywords: "key word", conference: "c2", sessionTime: "30" }, true);
+    await expectation;
+    
+    expect(mockSessionRepository.getSessions).toHaveBeenCalledWith({
+      conferenceId: "c2",
+      minutes: 30,
+      keywords: ["key", "word"]
+    });
+  });
+  
+  it("contains found sessions", async () => {
+    let searchResultResolver: (value: FilteredSessions) => void = _ => {};
+    mockSessionRepository.getSessions.mockReturnValue(new Promise(resolve => { searchResultResolver = resolve; }));
+    
+    const logic = createLogic();
+    
+    // Execute filter and wait until it starts loading.
+    const observer = new EventuallyObserver<SessionListIRDE>();
+    const expectation1 = observer.expectValue(sessionList => {
+      expect(sessionList.type).toBe(IRDETypes.Running);
+    });
+    subscription.add(logic.sessionList$.subscribe(observer));
+    logic.executeFilter( { keywords: "key word", conference: undefined, sessionTime: undefined }, true);
+    await expectation1;
+    
+    // Provide result sessions and wait it become "Done". 
+    let sessions = [] as SessionItem[];
+    let keywordList = [] as string[];
+    let moreRequest = { type: MoreRequestTypes.Unrequestable } as MoreRequest;
+    const expectation2 = observer.expectValue(sessionList => {
+      expect(sessionList.type).toBe(IRDETypes.Done);
+      if (sessionList.type === IRDETypes.Done) {
+        sessions = sessionList.sessions;
+        keywordList = sessionList.keywordList;
+        moreRequest = sessionList.moreRequest;
+      }
+    });
+    searchResultResolver({
+      sessions: sessions1,
+      more: undefined,
+    });
+    await expectation2;
+    
+    // Check result
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0].session).toBe(sessions1[0]);
+    expect(sessions[0].conferenceName).toBe("Conf 1");
+    expect(sessions[0].watchedEvents).toEqual([
+      {id: "e3", name: "Event 3"},
+      {id: "e1", name: "Event 1"},
+    ]);
+
+    expect(sessions[1].session).toBe(sessions1[1]);
+    expect(sessions[1].conferenceName).toBe("Conf 2");
+    expect(sessions[1].watchedEvents).toEqual([]);
+    
+    expect(keywordList).toEqual(["key", "word"]);
+    
+    expect(moreRequest).toEqual({ type: MoreRequestTypes.Unrequestable });
+  });
+  
+  it("can search more sessions", async () => {
+    let secondResult: FilteredSessions = {
+      sessions: sessions2,
+      more: undefined,
+    };
+    let firstResult: FilteredSessions = {
+      sessions: sessions1,
+      more: async () => {
+        return secondResult;
+      },
+    };
+    mockSessionRepository.getSessions.mockResolvedValue(firstResult);
+
+    const logic = createLogic();
+
+    // Execute filter and wait until it gets loaded.
+    let sessions: SessionItem[] = [];
+    let moreRequest = { type: MoreRequestTypes.Requesting } as MoreRequest;
+    const observer = new EventuallyObserver<SessionListIRDE>();
+    const expectation1 = observer.expectValue(sessionList => {
+      expect(sessionList.type).toBe(IRDETypes.Done);
+      const sessionListDone = sessionList as IRDEDone<SessionListDoneProp>
+      sessions = sessionListDone.sessions;
+      moreRequest = sessionListDone.moreRequest;
+    });
+    subscription.add(logic.sessionList$.subscribe(observer));
+    logic.executeFilter( { keywords: "key word", conference: undefined, sessionTime: undefined }, true);
+    await expectation1;
+    
+    // Check two sessions are found.
+    expect(sessions).toHaveLength(2);
+    
+    // It can request searching more sessions.
+    expect(moreRequest.type).toBe(MoreRequestTypes.Requestable);
+    
+    // Request
+    const expectation2 = observer.expectValue(sessionList => {
+      expect(sessionList.type).toBe(IRDETypes.Done);
+      const sessionListDone = sessionList as IRDEDone<SessionListDoneProp>
+      expect(sessionListDone.sessions).toHaveLength(3);
+      sessions = sessionListDone.sessions;
+      moreRequest = sessionListDone.moreRequest;
+    })
+    if (moreRequest.type === MoreRequestTypes.Requestable) {
+      moreRequest.request();
+    }
+    await expectation2;
+  });
+  
+  it("shows error message on error", async () => {
+    const searchError = new Error("Expected error on searching sessions");
+    mockSessionRepository.getSessions.mockRejectedValue(searchError);
+    
+    const logic = createLogic();
+
+    let message = "" as string;
+    const observer = new EventuallyObserver<SessionListIRDE>();
+    const expectation = observer.expectValue(sessionList => {
+      expect(sessionList.type).toBe(IRDETypes.Error);
+      const sessionListError = sessionList as IRDEError<SessionListErrorProp>
+      message = sessionListError.message;
+    });
+    subscription.add(logic.sessionList$.subscribe(observer));
+    logic.executeFilter( { keywords: "key word", conference: undefined, sessionTime: undefined }, true);
+    await expectation;
+    
+    expect(message).toBe(errorMessage(searchError));
+  });
+  
+  it("can be cleared", async () => {
+    const logic = createLogic();
+    
+    // Search and wait until it shows found sessions.
+    const observer = new EventuallyObserver<SessionListIRDE>();
+    const expectation1 = observer.expectValue(sessionList => {
+      expect(sessionList.type).toBe(IRDETypes.Done);
+    });
+    subscription.add(logic.sessionList$.subscribe(observer));
+    logic.executeFilter( { keywords: "key word", conference: undefined, sessionTime: undefined }, true);
+    await expectation1;
+    
+    // Clear search result.
+    const expectation2 = observer.expectValue(sessionList => {
+      expect(sessionList.type).toBe(IRDETypes.Initial);
+    });
+    logic.clearFilter();
+    await expectation2;
+  });
+
+  it("does search again even though same filter is specified", async () => {
+    const logic = createLogic();
+
+    logic.executeFilter({ keywords: "keyword", conference: undefined, sessionTime: undefined}, true);
+    logic.executeFilter({ keywords: "keyword", conference: undefined, sessionTime: undefined}, true);
+
+    // Wait for asynchronous processing.
+    await delay(500);
+
+    expect(mockSessionRepository.getSessions).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not search again when same filter is specified", async () => {
+    const logic = createLogic();
+    
+    logic.executeFilter({ keywords: "keyword", conference: undefined, sessionTime: undefined}, false);
+    logic.executeFilter({ keywords: "keyword", conference: undefined, sessionTime: undefined}, false);
+
+    // Wait for asynchronous processing.
+    await delay(500);
+    
+    expect(mockSessionRepository.getSessions).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/session/SessionLogic.test.ts
+++ b/src/features/session/SessionLogic.test.ts
@@ -24,7 +24,7 @@
 
 import { SessionFilter, SessionRepository } from "./SessionRepository";
 import { NEVER, Observable, startWith, Subscription, throwError } from "rxjs";
-import { Event } from "../../entities/Event";
+// import { Event } from "../../entities/Event";
 import { Conference } from "../../entities/Conference";
 // import { Session } from "../../entities/Session";
 import { AppSessionLogic, SessionLogic } from "./SessionLogic";
@@ -33,7 +33,7 @@ import { DropdownState } from "../../utils/Dropdown";
 
 class MockSessionRepository implements SessionRepository {
   getAllConferences$ = jest.fn(() => NEVER as Observable<Conference[]>);
-  getAllEvents$ = jest.fn(() => NEVER as Observable<Event[]>);
+  getAllEvents = jest.fn(async () => []);
   getSessions = jest.fn(async (_: SessionFilter) => ({ sessions: [], more: undefined }));
 }
 

--- a/src/features/session/SessionLogic.ts
+++ b/src/features/session/SessionLogic.ts
@@ -73,7 +73,7 @@ export interface SessionLogic extends Logic {
   filterConferenceChanged(value: string): void;
   filterSessionTimeChanged(value: string): void;
   filterKeywordsChanged(value: string): void;
-  executeFilter(params: FilterParams): void;
+  executeFilter(params: FilterParams, force: boolean): void;
   clearFilter(): void;
 
   isFilterPanelExpanded$: Observable<boolean>;
@@ -81,7 +81,6 @@ export interface SessionLogic extends Logic {
   filterSessionTime$: Observable<DropdownState>;
   filterKeywords$: Observable<string>;
   sessionList$: Observable<SessionListIRDE>;
-  currentFilterParams: FilterParams | undefined;
 }
 
 export class NullSessionLogic implements SessionLogic {
@@ -91,7 +90,7 @@ export class NullSessionLogic implements SessionLogic {
   filterConferenceChanged(value: string) {}
   filterSessionTimeChanged(value: string) {}
   filterKeywordsChanged(value: string) {}
-  executeFilter(params: FilterParams) {}
+  executeFilter(params: FilterParams, force: boolean) {}
   clearFilter() {}
 
   isFilterPanelExpanded$ = NEVER;
@@ -99,7 +98,6 @@ export class NullSessionLogic implements SessionLogic {
   filterSessionTime$ = NEVER;
   filterKeywords$ = NEVER;
   sessionList$ = NEVER;
-  currentFilterParams = undefined;
 }
 
 const UNSPECIFIED_STATE: DropdownState = { value: "-", items: [{ value: "-", title: "指定なし" }]};
@@ -119,7 +117,7 @@ export class AppSessionLogic implements SessionLogic {
   });
   filterKeywords$ = new BehaviorSubject("");
   sessionList$ = new BehaviorSubject<SessionListIRDE>({ type: IRDETypes.Initial });
-  currentFilterParams: FilterParams | undefined = undefined;
+  private currentFilterParams: FilterParams | undefined = undefined;
   
   constructor(private readonly repository: SessionRepository) {
     this.subscription.add(
@@ -180,8 +178,9 @@ export class AppSessionLogic implements SessionLogic {
     this.filterKeywords$.next(value);
   }
 
-  executeFilter(filterParams: FilterParams) {
-    if (this.currentFilterParams?.conference === filterParams.conference &&
+  executeFilter(filterParams: FilterParams, force: boolean) {
+    if (!force &&
+        this.currentFilterParams?.conference === filterParams.conference &&
         this.currentFilterParams?.sessionTime === filterParams.sessionTime &&
         this.currentFilterParams?.keywords === filterParams.keywords) {
       return;
@@ -277,6 +276,7 @@ export class AppSessionLogic implements SessionLogic {
   }
   
   clearFilter() {
+    this.isFilterPanelExpanded$.next(true);
     this.currentFilterParams = undefined;
     this.sessionList$.next({ type: IRDETypes.Initial });
   }

--- a/src/features/session/SessionLogic.ts
+++ b/src/features/session/SessionLogic.ts
@@ -42,12 +42,18 @@ export interface SessionItem {
 
 export type SessionListIRDE = IRDE<{}, {}, { sessions: SessionItem[], keywordList: string[] }, { message: string }>;
 
+export interface FilterParams {
+  conference: string | undefined;
+  sessionTime: string | undefined;
+  keywords: string;
+}
+
 export interface SessionLogic extends Logic {
   expandFilterPanel(isExpand: boolean): void;
   filterConferenceChanged(value: string): void;
   filterSessionTimeChanged(value: string): void;
   filterKeywordsChanged(value: string): void;
-  executeFilter(): void;
+  executeFilter(params: FilterParams | undefined): void;
 
   isFilterPanelExpanded$: Observable<boolean>;
   filterConference$: Observable<DropdownState>;
@@ -63,7 +69,7 @@ export class NullSessionLogic implements SessionLogic {
   filterConferenceChanged(value: string) {}
   filterSessionTimeChanged(value: string) {}
   filterKeywordsChanged(value: string) {}
-  executeFilter() {}
+  executeFilter(params: FilterParams | undefined) {}
   
   isFilterPanelExpanded$ = NEVER;
   filterConference$ = NEVER;
@@ -89,6 +95,7 @@ export class AppSessionLogic implements SessionLogic {
   });
   filterKeywords$ = new BehaviorSubject("");
   sessionList$ = new BehaviorSubject({ type: IRDETypes.Initial });
+  private currentFilterParams: FilterParams | undefined = undefined;
   
   constructor(private readonly repository: SessionRepository) {
     this.subscription.add(
@@ -148,7 +155,21 @@ export class AppSessionLogic implements SessionLogic {
   filterKeywordsChanged(value: string) {
     this.filterKeywords$.next(value);
   }
-  
-  executeFilter() {
+
+  executeFilter(filterParams: FilterParams | undefined) {
+    if (this.currentFilterParams?.conference === filterParams?.conference &&
+        this.currentFilterParams?.sessionTime === filterParams?.sessionTime &&
+        this.currentFilterParams?.keywords === filterParams?.keywords) {
+      return;
+    }
+    
+    this.currentFilterParams = filterParams;
+    
+    this.filterChanged(this.currentFilterParams?.conference ?? "-", this.filterConference$);
+    this.filterChanged(this.currentFilterParams?.sessionTime ?? "-", this.filterSessionTime$);
+    this.filterKeywords$.next(this.currentFilterParams?.keywords ?? "");
+    
+    // TODO:
+    console.log("filter", this.currentFilterParams);
   }
 }

--- a/src/features/session/SessionLogic.ts
+++ b/src/features/session/SessionLogic.ts
@@ -60,6 +60,7 @@ export interface SessionLogic extends Logic {
   filterSessionTime$: Observable<DropdownState>;
   filterKeywords$: Observable<string>;
   sessionList$: Observable<SessionListIRDE>;
+  currentFilterParams: FilterParams | undefined;
 }
 
 export class NullSessionLogic implements SessionLogic {
@@ -76,6 +77,7 @@ export class NullSessionLogic implements SessionLogic {
   filterSessionTime$ = NEVER;
   filterKeywords$ = NEVER;
   sessionList$ = NEVER;
+  currentFilterParams = undefined;
 }
 
 const UNSPECIFIED_STATE: DropdownState = { value: "-", items: [{ value: "-", title: "指定なし" }]};
@@ -95,7 +97,7 @@ export class AppSessionLogic implements SessionLogic {
   });
   filterKeywords$ = new BehaviorSubject("");
   sessionList$ = new BehaviorSubject({ type: IRDETypes.Initial });
-  private currentFilterParams: FilterParams | undefined = undefined;
+  currentFilterParams: FilterParams | undefined = undefined;
   
   constructor(private readonly repository: SessionRepository) {
     this.subscription.add(

--- a/src/features/session/SessionSearchFilter.tsx
+++ b/src/features/session/SessionSearchFilter.tsx
@@ -66,9 +66,24 @@ function SessionSearchFilterCard({ isExpanded, onExpand }: SessionSearchFilterCa
 
   useEffect(() => {
     const keywords = searchParams.get("q");
-    if (keywords === null) {
-      sessionLogic.executeFilter(undefined);
-    } else {
+    if (keywords === null) { // When filter is not specified
+      if (sessionLogic.currentFilterParams !== undefined) { // When logic has filter, i.e. it has search result
+        // Reflect the logic's filter to search params.
+        const params: { [key: string]: string } = {};
+        const currentFilterToParams = (name: string, value: string | undefined) => {
+          if (value !== undefined) {
+            params[name] = value;
+          }
+        }
+        
+        currentFilterToParams("q", sessionLogic.currentFilterParams.keywords);
+        currentFilterToParams("c", sessionLogic.currentFilterParams.conference);
+        currentFilterToParams("t", sessionLogic.currentFilterParams.sessionTime);
+        
+        setSearchParams(params);
+      }
+    } else { // When filter is specified
+      // Execute specified filter.
       sessionLogic.executeFilter({
         conference: searchParams.get("c") ?? undefined,
         sessionTime: searchParams.get("t") ?? undefined,
@@ -80,6 +95,7 @@ function SessionSearchFilterCard({ isExpanded, onExpand }: SessionSearchFilterCa
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     
+    // Convert form data to search params.
     const formData = new FormData(event.currentTarget);
     const params: { [key: string]: string } = {};
     const formDataToParams = (name: string, except: string | undefined, none: string | undefined) => {

--- a/src/features/session/SessionSearchFilter.tsx
+++ b/src/features/session/SessionSearchFilter.tsx
@@ -67,28 +67,14 @@ function SessionSearchFilterCard({ isExpanded, onExpand }: SessionSearchFilterCa
   useEffect(() => {
     const keywords = searchParams.get("q");
     if (keywords === null) { // When filter is not specified
-      if (sessionLogic.currentFilterParams !== undefined) { // When logic has filter, i.e. it has search result
-        // Reflect the logic's filter to search params.
-        const params: { [key: string]: string } = {};
-        const currentFilterToParams = (name: string, value: string | undefined) => {
-          if (value !== undefined) {
-            params[name] = value;
-          }
-        }
-        
-        currentFilterToParams("q", sessionLogic.currentFilterParams.keywords);
-        currentFilterToParams("c", sessionLogic.currentFilterParams.conference);
-        currentFilterToParams("t", sessionLogic.currentFilterParams.sessionTime);
-        
-        setSearchParams(params);
-      }
+      sessionLogic.clearFilter();
     } else { // When filter is specified
       // Execute specified filter.
       sessionLogic.executeFilter({
         conference: searchParams.get("c") ?? undefined,
         sessionTime: searchParams.get("t") ?? undefined,
         keywords,
-      });
+      }, false);
     }
   }, [sessionLogic, searchParams, setSearchParams]);
   
@@ -111,12 +97,11 @@ function SessionSearchFilterCard({ isExpanded, onExpand }: SessionSearchFilterCa
     formDataToParams("c", "-", undefined);
     formDataToParams("t", "-", undefined);
     
-    sessionLogic.clearFilter();
     sessionLogic.executeFilter({
       conference: params["c"] ?? undefined,
       sessionTime: params["t"] ?? undefined,
       keywords: params["q"] ?? "",
-    });
+    }, true);
     setSearchParams(params);
   }
   

--- a/src/features/session/SessionSearchFilter.tsx
+++ b/src/features/session/SessionSearchFilter.tsx
@@ -37,9 +37,10 @@ import {
 } from "@mui/material";
 import { ExpandLess, ExpandMore } from "@mui/icons-material";
 import { Dropdown, EMPTY_DROPDOWN } from "../../utils/Dropdown";
-import { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import { SessionContext } from "./SessionContext";
 import { useObservableState } from "observable-hooks";
+import { useSearchParams } from "react-router-dom";
 
 export function SessionSearchFilter(): JSX.Element {
   const sessionLogic = useContext(SessionContext);
@@ -61,7 +62,42 @@ function SessionSearchFilterCard({ isExpanded, onExpand }: SessionSearchFilterCa
   const conference = useObservableState(sessionLogic.filterConference$, EMPTY_DROPDOWN);
   const sessionTime = useObservableState(sessionLogic.filterSessionTime$, EMPTY_DROPDOWN);
   const keyword = useObservableState(sessionLogic.filterKeywords$, "");
+  const [searchParams, setSearchParams] = useSearchParams();
 
+  useEffect(() => {
+    const keywords = searchParams.get("q");
+    if (keywords === null) {
+      sessionLogic.executeFilter(undefined);
+    } else {
+      sessionLogic.executeFilter({
+        conference: searchParams.get("c") ?? undefined,
+        sessionTime: searchParams.get("t") ?? undefined,
+        keywords,
+      });
+    }
+  }, [sessionLogic, searchParams]);
+  
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    
+    const formData = new FormData(event.currentTarget);
+    const params: { [key: string]: string } = {};
+    const formDataToParams = (name: string, except: string | undefined, none: string | undefined) => {
+      const data = formData.get(name);
+      if (data != null && typeof data === "string" && data !== except) {
+        params[name] = data;
+      } else if (none !== undefined) {
+        params[name] = none;
+      }
+    }
+
+    formDataToParams("q", undefined, "");
+    formDataToParams("c", "-", undefined);
+    formDataToParams("t", "-", undefined);
+    
+    setSearchParams(params);
+  }
+  
   return (
     <Card variant="outlined">
       <CardContent>
@@ -80,29 +116,31 @@ function SessionSearchFilterCard({ isExpanded, onExpand }: SessionSearchFilterCa
       </CardContent>
 
       <Collapse in={isExpanded}>
-        <CardContent>
-          <Stack direction="column" spacing={3}>
-            <Stack direction={{ xs: "column", sm: "row" }} spacing={3}>
-              <Dropdown labelId="conference" label="カンファレンス" state={conference} minWidth={150} onChange={ value => sessionLogic.filterConferenceChanged(value) }/>
-              <Dropdown labelId="minutes" label="セッション時間" state={sessionTime} minWidth={150} onChange={ value => sessionLogic.filterSessionTimeChanged(value) }/>
+        <form onSubmit={handleSubmit}>
+          <CardContent>
+            <Stack direction="column" spacing={3}>
+              <TextField type="text" name="q" autoFocus={false}
+                         label="キーワード" placeholder="スペースで区切って指定（AND検索）"
+                         margin="none"
+                         fullWidth={true}
+                         onChange={event => sessionLogic.filterKeywordsChanged(event.target.value)}
+                         value={keyword}
+                         InputLabelProps={{ shrink: true }}/>
+              <Stack direction={{ xs: "column", sm: "row" }} spacing={3}>
+                <Dropdown name="c" labelId="conference" label="カンファレンス" state={conference} minWidth={150} onChange={ value => sessionLogic.filterConferenceChanged(value) }/>
+                <Dropdown name="t" labelId="minutes" label="セッション時間" state={sessionTime} minWidth={150} onChange={ value => sessionLogic.filterSessionTimeChanged(value) }/>
+              </Stack>
             </Stack>
-            <TextField type="text" autoFocus={false}
-                       label="キーワード" placeholder="スペースで区切って指定（AND検索）"
-                       margin="none"
-                       fullWidth={true}
-                       onChange={event => sessionLogic.filterKeywordsChanged(event.target.value)}
-                       value={keyword}
-                       InputLabelProps={{ shrink: true }}/>
-          </Stack>
-        </CardContent>
-
-        <CardActions>
-          <Grid container={true}>
-            <Grid item={true} xs={12} sx={{ textAlign: "end" }}>
-              <Button size="small" color="primary" onClick={() => { sessionLogic.executeFilter() }}>実行</Button>
+          </CardContent>
+  
+          <CardActions>
+            <Grid container={true}>
+              <Grid item={true} xs={12} sx={{ textAlign: "end" }}>
+                <Button size="small" color="primary" type="submit">実行</Button>
+              </Grid>
             </Grid>
-          </Grid>
-        </CardActions>
+          </CardActions>
+        </form>
       </Collapse>
     </Card>
   );

--- a/src/features/session/SessionSearchFilter.tsx
+++ b/src/features/session/SessionSearchFilter.tsx
@@ -90,7 +90,7 @@ function SessionSearchFilterCard({ isExpanded, onExpand }: SessionSearchFilterCa
         keywords,
       });
     }
-  }, [sessionLogic, searchParams]);
+  }, [sessionLogic, searchParams, setSearchParams]);
   
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -111,6 +111,12 @@ function SessionSearchFilterCard({ isExpanded, onExpand }: SessionSearchFilterCa
     formDataToParams("c", "-", undefined);
     formDataToParams("t", "-", undefined);
     
+    sessionLogic.clearFilter();
+    sessionLogic.executeFilter({
+      conference: params["c"] ?? undefined,
+      sessionTime: params["t"] ?? undefined,
+      keywords: params["q"] ?? "",
+    });
     setSearchParams(params);
   }
   

--- a/src/utils/Delay.ts
+++ b/src/utils/Delay.ts
@@ -1,0 +1,27 @@
+//
+// Delay.ts
+//
+// Copyright (c) 2022 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+export function delay(msec: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, msec));
+}

--- a/src/utils/Dropdown.tsx
+++ b/src/utils/Dropdown.tsx
@@ -36,6 +36,7 @@ export interface DropdownStateItem {
 }
 
 interface DropdownProps {
+  name?: string;
   labelId: string;
   label: string;
   state: DropdownState;
@@ -45,11 +46,11 @@ interface DropdownProps {
 
 export const EMPTY_DROPDOWN: DropdownState = { value: "", items: [] };
 
-export function Dropdown({ labelId, label, state, minWidth, onChange }: DropdownProps): JSX.Element {
+export function Dropdown({ name, labelId, label, state, minWidth, onChange }: DropdownProps): JSX.Element {
   return (
     <FormControl sx={{ minWidth }}>
       <InputLabel id={labelId}>{label}</InputLabel>
-      <Select labelId={labelId} label={label} value={state.value} onChange={event => onChange(event.target.value)}>
+      <Select name={name} labelId={labelId} label={label} value={state.value} onChange={event => onChange(event.target.value)}>
         {
           state.items.map(item => (
             <MenuItem key={item.value} value={item.value}>

--- a/src/utils/ErrorMessage.ts
+++ b/src/utils/ErrorMessage.ts
@@ -1,0 +1,33 @@
+//
+// ErrorMessage.ts
+//
+// Copyright (c) 2022 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+export function errorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  } else if (err instanceof Object) {
+    return err.toString();
+  } else {
+    return typeof err;
+  }
+}

--- a/src/utils/ExecuteOnce.ts
+++ b/src/utils/ExecuteOnce.ts
@@ -1,0 +1,38 @@
+//
+// ExecuteOnce.ts
+//
+// Copyright (c) 2022 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+/**
+ * Returns a function which executes the specified block on the first call and does nothing on subsequent calls.
+ * @param block A function that will run on first call.
+ */
+export function executeOnce(block: () => void): () => void {
+  let proc: (() => void) | undefined = block;
+  return () => {
+    if (proc !== undefined) {
+      const p = proc;
+      proc = undefined;
+      p();
+    }
+  };
+}

--- a/src/utils/RunDetached.ts
+++ b/src/utils/RunDetached.ts
@@ -1,0 +1,29 @@
+//
+// RunDetached.ts
+//
+// Copyright (c) 2022 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+export function runDetached<T>(fn: () => Promise<T>): void {
+  fn().catch(e => {
+    console.error(e);
+  });
+}


### PR DESCRIPTION
Video sessions are now able to be searched with specified filter.

- A maximum number of sessions retrieved from Firebase at once is limited to 100.
- Keyword filter is applied after retrieving sessions with other filters from Firebase.
- So 100, or <100 sessions (especially when keyword is specified) are shown at once.
- When user clicks "もっと探す" (Search More) button, the next ≦100 sessions are searched.
