### PR TITLE
Fix request detail icon

### DIFF
--- a/src/features/request_detail/RequestDetailDialog.tsx
+++ b/src/features/request_detail/RequestDetailDialog.tsx
@@ -34,7 +34,7 @@ import {
   useMediaQuery,
   useTheme
 } from "@mui/material";
-import { Close, Note, OndemandVideo } from "@mui/icons-material";
+import { ArrowBack, Note, OndemandVideo } from "@mui/icons-material";
 import { IRDETypes } from "../../utils/IRDE";
 import { RequestDetail } from "./RequestDetailLogic";
 import { useNavigate, useParams } from "react-router-dom";
@@ -77,7 +77,7 @@ export function RequestDetailDialog(): JSX.Element {
           <AppBar>
             <Toolbar>
               <IconButton color="inherit" onClick={onClose} aria-label="Close">
-                <Close/>
+                <ArrowBack/>
               </IconButton>
             </Toolbar>
           </AppBar>


### PR DESCRIPTION
The upper left corner icon of the request detail dialog, it will be shown when screen size is narrow, was accidentally changed to "x" icon.
This PR fixes it.

| Before | After |
|--------|------|
| <img width="274" alt="before" src="https://user-images.githubusercontent.com/1498691/185728978-527dc72f-98b0-4b1b-a8f6-0e3ca5fe7725.png"> | <img width="274" alt="after" src="https://user-images.githubusercontent.com/1498691/185728991-f349a063-385f-4ffc-b3df-e1cb31e477e7.png">  |

 