### PR TITLE
Cut out all Firestore access functions into Firestore.ts

### DIFF
--- a/src/Firestore.ts
+++ b/src/Firestore.ts
@@ -1,0 +1,263 @@
+//
+// Firestore.ts
+//
+// Copyright (c) 2022 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import { map, Observable } from "rxjs";
+import { Config, configConverter } from "./entities/Config";
+import { getFirestore, withFirestore } from "./Firebase";
+import {
+  collection,
+  doc,
+  DocumentSnapshot,
+  getDocs,
+  limit,
+  onSnapshot,
+  orderBy,
+  query,
+  startAfter,
+  where
+} from "firebase/firestore";
+import { Event, eventConverter } from "./entities/Event";
+import { Query, QuerySnapshot } from "@firebase/firestore";
+import { Request, requestConverter } from "./entities/Request";
+import { Session, sessionConverter } from "./entities/Session";
+import { Conference, conferenceConverter } from "./entities/Conference";
+import { CaseInsensitiveSearch } from "./utils/CaseInsensitiveSearch";
+
+export interface SessionFilter {
+  conferenceId?: string,
+  minutes?: number,
+  keywords?: string[],
+}
+
+export interface FilteredSessions {
+  sessions: Session[];
+  more: (() => Promise<FilteredSessions>) | undefined;
+}
+
+export class Firestore {
+  static getConfig$(): Observable<Config> {
+    return withFirestore(firestore => {
+      const collectionRef = collection(firestore, "config");
+      const docRef = doc(collectionRef, "config").withConverter(configConverter);
+      return new Observable<DocumentSnapshot<Config>>(subscriber => {
+        return onSnapshot(docRef, subscriber);
+      }).pipe(
+        map(snapshot => {
+          const config = snapshot.data();
+          if (config === undefined) {
+            throw new Error("Configuration value is not found on Firestore!");
+          }
+          return config;
+        }),
+      );
+    });
+  }
+
+  static async getAllEvents(): Promise<Event[]> {
+    const firestore = await getFirestore();
+    const collectionRef = collection(firestore, "events");
+    const docQuery = query(collectionRef,
+      where("hidden", "==", false),
+      orderBy("starts", "desc"),
+    ).withConverter(eventConverter);
+    const snapshot = await getDocs(docQuery);
+    return snapshot.docs.map(doc => doc.data());
+  }
+  
+  static getAllEvents$(): Observable<Event[]> {
+    return withFirestore(firestore => {
+      const collectionRef = collection(firestore, "events");
+      const docQuery = query(collectionRef,
+        where("hidden", "==", false),
+        orderBy("starts", "desc"),
+      ).withConverter(eventConverter);
+      return new Observable<QuerySnapshot<Event>>(subscriber => {
+        return onSnapshot(docQuery, subscriber);
+      }).pipe(
+        map(snapshot => {
+          return snapshot
+            .docs
+            .map(it => it.data())
+        }),
+      );
+    });
+  }
+
+  static getAllRequests$(eventId: string): Observable<Request[]> {
+    return withFirestore(firestore => {
+      const collectionRef = collection(firestore, "events", eventId, "requests");
+      const docQuery = query(collectionRef,
+        orderBy("requestedAt", "asc"),
+      ).withConverter(requestConverter);
+      return new Observable<QuerySnapshot<Request>>(subscriber => {
+        return onSnapshot(docQuery, subscriber);
+      }).pipe(
+        map(snapshot => {
+          return snapshot
+            .docs
+            .map(it => it.data())
+        }),
+      );
+    });
+  }
+
+  static getRequest$(eventId: string, requestId: string): Observable<Request> {
+    return withFirestore(firestore => {
+      const collectionRef = collection(firestore, "events", eventId, "requests");
+      const docRef = doc(collectionRef, requestId).withConverter(requestConverter);
+      return new Observable<DocumentSnapshot<Request>>(subscriber => {
+        return onSnapshot(docRef, subscriber);
+      }).pipe(
+        map(snapshot => {
+          const request = snapshot.data();
+          if (request === undefined) {
+            throw new Error(`Request is not found.`);
+          }
+          return request;
+        }),
+      );
+    });
+  }
+
+  static async getSessions(filter: SessionFilter): Promise<FilteredSessions> {
+    const LIMIT = 100;
+    const firestore = await getFirestore();
+    const collectionRef = collection(firestore, "sessions");
+    let docQuery: Query<Session> = collectionRef.withConverter(sessionConverter);
+    if (filter.conferenceId !== undefined) {
+      docQuery = query(docQuery, where("conferenceId", "==", filter.conferenceId));
+    }
+    if (filter.minutes !== undefined) {
+      docQuery = query(docQuery, where("minutes", "==", filter.minutes));
+    }
+    docQuery = query(docQuery,
+      orderBy("starts", "asc"),
+      limit(LIMIT),
+    );
+    return await filterSessions(docQuery);
+
+    async function filterSessions(docQuery: Query<Session>): Promise<FilteredSessions> {
+      const snapshot = await getDocs(docQuery);
+      const sessions = snapshot
+        .docs
+        .map(doc => doc.data())
+        .filter(filterByKeywords(filter.keywords));
+      let more: (() => Promise<FilteredSessions>) | undefined = undefined;
+      if (snapshot.size === LIMIT) {
+        const nextQuery = query(docQuery, startAfter(snapshot.docs[snapshot.docs.length - 1]));
+        more = async () => await filterSessions(nextQuery);
+      }
+      return { sessions, more };
+    }
+
+    function filterByKeywords(keywords?: string[]): (session: Session) => boolean {
+      if (keywords === undefined) {
+        return _ => true;
+      }
+
+      return session => {
+        for (const keyword of keywords) {
+          const searcher = new CaseInsensitiveSearch(keyword);
+
+          if (!searcher.foundIn(session.title)) {
+            if (!searcher.foundIn(session.description)) {
+              let found = false;
+              for (const speaker of session.speakers) {
+                if (searcher.foundIn(speaker.name)) {
+                  found = true;
+                  break;
+                }
+                if (speaker.twitter !== undefined) {
+                  if (searcher.foundIn(speaker.twitter)) {
+                    found = true;
+                    break;
+                  }
+                }
+              }
+              if (!found) {
+                return false;
+              }
+            }
+          }
+        }
+
+        return true;
+      };
+    }
+  }
+  
+  static getSession$(sessionId: string): Observable<Session> {
+    return withFirestore(firestore => {
+      const collectionRef = collection(firestore, "sessions");
+      const docRef = doc(collectionRef, sessionId).withConverter(sessionConverter);
+      return new Observable<DocumentSnapshot<Session>>(subscriber => {
+        return onSnapshot(docRef, subscriber);
+      }).pipe(
+        map(snapshot => {
+          const session = snapshot.data();
+          if (session === undefined) {
+            throw new Error(`Session is not found.`);
+          }
+          return session;
+        }),
+      );
+    });
+  }
+
+  static getAllConferences$(): Observable<Conference[]> {
+    return withFirestore(firestore => {
+      const collectionRef = collection(firestore, "conferences");
+      const docQuery = query(collectionRef,
+        orderBy("starts", "desc"),
+      ).withConverter(conferenceConverter);
+      return new Observable<QuerySnapshot<Conference>>(subscriber => {
+        return onSnapshot(docQuery, subscriber);
+      }).pipe(
+        map(snapshot => {
+          return snapshot
+            .docs
+            .map(it => it.data())
+        }),
+      );
+    });
+  }
+  
+  static getConferenceName$(conferenceId: string): Observable<string> {
+    return withFirestore(firestore => {
+      const collectionRef = collection(firestore, "conferences");
+      const docRef = doc(collectionRef, conferenceId).withConverter(conferenceConverter);
+      return new Observable<DocumentSnapshot<Conference>>(subscriber => {
+        return onSnapshot(docRef, subscriber);
+      }).pipe(
+        map(snapshot => {
+          const conference = snapshot.data();
+          if (conference === undefined) {
+            throw new Error(`Conference is not found.`);
+          }
+          return conference.name;
+        }),
+      );
+    });
+  }
+}

--- a/src/features/home/HomeRepository.ts
+++ b/src/features/home/HomeRepository.ts
@@ -22,10 +22,9 @@
 // THE SOFTWARE.
 //
 
-import { map, Observable } from "rxjs";
-import { Config, configConverter } from "../../entities/Config";
-import { withFirestore } from "../../Firebase";
-import { collection, doc, DocumentSnapshot, onSnapshot } from 'firebase/firestore';
+import { Observable } from "rxjs";
+import { Config } from "../../entities/Config";
+import { Firestore } from "../../Firestore";
 
 export interface HomeRepository {
   getConfig$(): Observable<Config>;
@@ -33,20 +32,6 @@ export interface HomeRepository {
 
 export class FirestoreHomeRepository implements HomeRepository {
   getConfig$(): Observable<Config> {
-    return withFirestore(firestore => {
-      const collectionRef = collection(firestore, "config");
-      const docRef = doc(collectionRef, "config").withConverter(configConverter);
-      return new Observable<DocumentSnapshot<Config>>(subscriber => {
-        return onSnapshot(docRef, subscriber);
-      }).pipe(
-        map(snapshot => {
-          const config = snapshot.data();
-          if (config === undefined) {
-            throw new Error("Configuration value is not found on Firestore!");
-          }
-          return config;
-        }),
-      );
-    });
+    return Firestore.getConfig$();
   }
 }

--- a/src/features/request/RequestRepository.ts
+++ b/src/features/request/RequestRepository.ts
@@ -22,12 +22,10 @@
 // THE SOFTWARE.
 //
 
-import { Event, eventConverter } from "../../entities/Event";
-import { Request, requestConverter } from "../../entities/Request";
-import { map, Observable } from "rxjs";
-import { withFirestore } from "../../Firebase";
-import { collection, onSnapshot, orderBy, query, where } from "firebase/firestore";
-import { QuerySnapshot } from "@firebase/firestore";
+import { Event } from "../../entities/Event";
+import { Request } from "../../entities/Request";
+import { Observable } from "rxjs";
+import { Firestore } from "../../Firestore";
 
 export interface RequestRepository {
   getAllEvents$(): Observable<Event[]>;
@@ -36,39 +34,10 @@ export interface RequestRepository {
 
 export class FirestoreRequestRepository implements RequestRepository {
   getAllEvents$(): Observable<Event[]> {
-    return withFirestore(firestore => {
-      const collectionRef = collection(firestore, "events");
-      const docQuery = query(collectionRef,
-        where("hidden", "==", false),
-        orderBy("starts", "desc"),
-      ).withConverter(eventConverter);
-      return new Observable<QuerySnapshot<Event>>(subscriber => {
-        return onSnapshot(docQuery, subscriber);
-      }).pipe(
-        map(snapshot => {
-          return snapshot
-            .docs
-            .map(it => it.data())
-        }),
-      );
-    });
+    return Firestore.getAllEvents$();
   }
   
   getAllRequests$(eventId: string): Observable<Request[]> {
-    return withFirestore(firestore => {
-      const collectionRef = collection(firestore, "events", eventId, "requests");
-      const docQuery = query(collectionRef,
-        orderBy("requestedAt", "asc"),
-      ).withConverter(requestConverter);
-      return new Observable<QuerySnapshot<Request>>(subscriber => {
-        return onSnapshot(docQuery, subscriber);
-      }).pipe(
-        map(snapshot => {
-          return snapshot
-            .docs
-            .map(it => it.data())
-        }),
-      );
-    });
+    return Firestore.getAllRequests$(eventId);
   }
 }

--- a/src/features/request_detail/RequestDetailRepository.ts
+++ b/src/features/request_detail/RequestDetailRepository.ts
@@ -22,14 +22,11 @@
 // THE SOFTWARE.
 //
 
-import { map, Observable } from "rxjs";
-import { Request, requestConverter } from "../../entities/Request";
-import { Session, sessionConverter } from "../../entities/Session";
-import { Event, eventConverter } from "../../entities/Event";
-import { withFirestore } from "../../Firebase";
-import { collection, doc, DocumentSnapshot, onSnapshot, orderBy, query, where } from "firebase/firestore";
-import { QuerySnapshot } from "@firebase/firestore";
-import { Conference, conferenceConverter } from "../../entities/Conference";
+import { Observable } from "rxjs";
+import { Request } from "../../entities/Request";
+import { Session } from "../../entities/Session";
+import { Event } from "../../entities/Event";
+import { Firestore } from "../../Firestore";
 
 export interface RequestDetailRepository {
   getRequest$(eventId: string, requestId: string): Observable<Request>;
@@ -40,75 +37,18 @@ export interface RequestDetailRepository {
 
 export class FirestoreRequestDetailRepository implements RequestDetailRepository {
   getRequest$(eventId: string, requestId: string): Observable<Request> {
-    return withFirestore(firestore => {
-      const collectionRef = collection(firestore, "events", eventId, "requests");
-      const docRef = doc(collectionRef, requestId).withConverter(requestConverter);
-      return new Observable<DocumentSnapshot<Request>>(subscriber => {
-        return onSnapshot(docRef, subscriber);
-      }).pipe(
-        map(snapshot => {
-          const request = snapshot.data();
-          if (request === undefined) {
-            throw new Error(`Request is not found.`);
-          }
-          return request;
-        }),
-      );
-    });    
+    return Firestore.getRequest$(eventId, requestId);
   }
   
   getSession$(sessionId: string): Observable<Session> {
-    return withFirestore(firestore => {
-      const collectionRef = collection(firestore, "sessions");
-      const docRef = doc(collectionRef, sessionId).withConverter(sessionConverter);
-      return new Observable<DocumentSnapshot<Session>>(subscriber => {
-        return onSnapshot(docRef, subscriber);
-      }).pipe(
-        map(snapshot => {
-          const session = snapshot.data();
-          if (session === undefined) {
-            throw new Error(`Session is not found.`);
-          }
-          return session;
-        }),
-      );
-    });
+    return Firestore.getSession$(sessionId);
   }
   
   getAllEvents$(): Observable<Event[]> {
-    return withFirestore(firestore => {
-      const collectionRef = collection(firestore, "events");
-      const docQuery = query(collectionRef,
-        where("hidden", "==", false),
-        orderBy("starts", "desc"),
-      ).withConverter(eventConverter);
-      return new Observable<QuerySnapshot<Event>>(subscriber => {
-        return onSnapshot(docQuery, subscriber);
-      }).pipe(
-        map(snapshot => {
-          return snapshot
-            .docs
-            .map(it => it.data())
-        }),
-      );
-    });
+    return Firestore.getAllEvents$();
   }
   
   getConferenceName$(conferenceId: string): Observable<string> {
-    return withFirestore(firestore => {
-      const collectionRef = collection(firestore, "conferences");
-      const docRef = doc(collectionRef, conferenceId).withConverter(conferenceConverter);
-      return new Observable<DocumentSnapshot<Conference>>(subscriber => {
-        return onSnapshot(docRef, subscriber);
-      }).pipe(
-        map(snapshot => {
-          const conference = snapshot.data();
-          if (conference === undefined) {
-            throw new Error(`Conference is not found.`);
-          }
-          return conference.name;
-        }),
-      );
-    });
+    return Firestore.getConferenceName$(conferenceId);
   }
 }

--- a/src/features/session/SessionLogic.test.ts
+++ b/src/features/session/SessionLogic.test.ts
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 //
 
-import { FilteredSessions, SessionFilter, SessionRepository } from "./SessionRepository";
+import { SessionRepository } from "./SessionRepository";
 import { NEVER, startWith, Subscription, throwError } from "rxjs";
 import { Event } from "../../entities/Event";
 import { Conference } from "../../entities/Conference";
@@ -42,6 +42,7 @@ import { DropdownState } from "../../utils/Dropdown";
 import { IRDEDone, IRDEError, IRDETypes } from "../../utils/IRDE";
 import { errorMessage } from "../../utils/ErrorMessage";
 import { delay } from "../../utils/Delay";
+import { FilteredSessions, SessionFilter } from "../../Firestore";
 
 class MockSessionRepository implements SessionRepository {
   getAllConferences$ = jest.fn(() => NEVER.pipe(startWith(conferences1)));

--- a/src/features/session/SessionLogic.ts
+++ b/src/features/session/SessionLogic.ts
@@ -27,11 +27,12 @@ import { Session } from "../../entities/Session";
 import { Logic } from "../../utils/LogicProvider";
 import { BehaviorSubject, NEVER, Observable, Subscription } from "rxjs";
 import { DropdownState } from "../../utils/Dropdown";
-import { FilteredSessions, SessionFilter, SessionRepository } from "./SessionRepository";
+import { SessionRepository } from "./SessionRepository";
 import { runDetached } from "../../utils/RunDetached";
 import { executeOnce } from "../../utils/ExecuteOnce";
 import { errorMessage } from "../../utils/ErrorMessage";
 import { IdAndName } from "../session_detail/WatchedEvents";
+import { FilteredSessions, SessionFilter } from "../../Firestore";
 
 export interface SessionItem {
   session: Session;

--- a/src/features/session/SessionRepository.ts
+++ b/src/features/session/SessionRepository.ts
@@ -22,25 +22,10 @@
 // THE SOFTWARE.
 //
 
-import { map, Observable } from "rxjs";
-import { Conference, conferenceConverter } from "../../entities/Conference";
-import { Session, sessionConverter } from "../../entities/Session";
-import { Event, eventConverter } from "../../entities/Event";
-import { getFirestore, withFirestore } from "../../Firebase";
-import { collection, getDocs, limit, onSnapshot, orderBy, query, startAfter, where } from "firebase/firestore";
-import { Query, QuerySnapshot } from "@firebase/firestore";
-import { CaseInsensitiveSearch } from "../../utils/CaseInsensitiveSearch";
-
-export interface SessionFilter {
-  conferenceId?: string,
-  minutes?: number,
-  keywords?: string[],
-}
-
-export interface FilteredSessions {
-  sessions: Session[];
-  more: (() => Promise<FilteredSessions>) | undefined;
-}
+import { Observable } from "rxjs";
+import { Conference } from "../../entities/Conference";
+import { Event } from "../../entities/Event";
+import { FilteredSessions, Firestore, SessionFilter } from "../../Firestore";
 
 export interface SessionRepository {
   getAllConferences$(): Observable<Conference[]>;
@@ -50,98 +35,14 @@ export interface SessionRepository {
 
 export class FirestoreSessionRepository implements SessionRepository {
   getAllConferences$(): Observable<Conference[]> {
-    return withFirestore(firestore => {
-      const collectionRef = collection(firestore, "conferences");
-      const docQuery = query(collectionRef,
-        orderBy("starts", "desc"),
-      ).withConverter(conferenceConverter);
-      return new Observable<QuerySnapshot<Conference>>(subscriber => {
-        return onSnapshot(docQuery, subscriber);
-      }).pipe(
-        map(snapshot => {
-          return snapshot
-            .docs
-            .map(it => it.data())
-        }),
-      );
-    });
+    return Firestore.getAllConferences$();
   }
 
-  async getAllEvents(): Promise<Event[]> {
-    const firestore = await getFirestore();
-    const collectionRef = collection(firestore, "events");
-    const docQuery = query(collectionRef,
-      where("hidden", "==", false),
-      orderBy("starts", "desc"),
-    ).withConverter(eventConverter);
-    const snapshot = await getDocs(docQuery);
-    return snapshot.docs.map(doc => doc.data());
+  getAllEvents(): Promise<Event[]> {
+    return Firestore.getAllEvents();
   }
 
-  async getSessions(filter: SessionFilter): Promise<FilteredSessions> {
-    const LIMIT = 100;
-    const firestore = await getFirestore();
-    const collectionRef = collection(firestore, "sessions");
-    let docQuery: Query<Session> = collectionRef.withConverter(sessionConverter);
-    if (filter.conferenceId !== undefined) {
-      docQuery = query(docQuery, where("conferenceId", "==", filter.conferenceId));
-    }
-    if (filter.minutes !== undefined) {
-      docQuery = query(docQuery, where("minutes", "==", filter.minutes));
-    }
-    docQuery = query(docQuery,
-      orderBy("starts", "asc"),
-      limit(LIMIT),
-    );
-    return await filterSessions(docQuery);
-    
-    async function filterSessions(docQuery: Query<Session>): Promise<FilteredSessions> {
-      const snapshot = await getDocs(docQuery);
-      const sessions = snapshot
-        .docs
-        .map(doc => doc.data())
-        .filter(filterByKeywords(filter.keywords));
-      let more: (() => Promise<FilteredSessions>) | undefined = undefined;
-      if (snapshot.size === LIMIT) {
-        const nextQuery = query(docQuery, startAfter(snapshot.docs[snapshot.docs.length - 1]));
-        more = async () => await filterSessions(nextQuery);
-      }
-      return { sessions, more };
-    }
-
-    function filterByKeywords(keywords?: string[]): (session: Session) => boolean {
-      if (keywords === undefined) {
-        return _ => true;
-      }
-
-      return session => {
-        for (const keyword of keywords) {
-          const searcher = new CaseInsensitiveSearch(keyword);
-
-          if (!searcher.foundIn(session.title)) {
-            if (!searcher.foundIn(session.description)) {
-              let found = false;
-              for (const speaker of session.speakers) {
-                if (searcher.foundIn(speaker.name)) {
-                  found = true;
-                  break;
-                }
-                if (speaker.twitter !== undefined) {
-                  if (searcher.foundIn(speaker.twitter)) {
-                    found = true;
-                    break;
-                  }
-                }
-              }
-              if (!found) {
-                return false;
-              }
-            }
-          }
-        }
-
-        return true;
-      };
-    }
+  getSessions(filter: SessionFilter): Promise<FilteredSessions> {
+    return Firestore.getSessions(filter);
   }
 }


### PR DESCRIPTION
Because many of functions that retrieve data from Firestore are commonly used in different repositories, put all these functions into `Firestore` class and call it from each repository.