### PR TITLE
Tweak code style setting for WebStorm/IntelliJ

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -3,6 +3,7 @@
     <TypeScriptCodeStyleSettings version="0">
       <option name="USE_SEMICOLON_AFTER_STATEMENT" value="false" />
       <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
     </TypeScriptCodeStyleSettings>
   </code_scheme>
 </component>


### PR DESCRIPTION
Update project code style for WebStorm/IntelliJ.

- Code Style -> TypeScript -> Spaces -> Within -> ES6 import/export braces (Turn it on)