### PR TITLE
Improve navigation to request page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import { HomeContext } from "./features/home/HomeContext"
 import { useObservableState } from "observable-hooks"
 import { CssBaseline } from "@mui/material"
 import { Maintenance } from "./features/home/Maintenance"
+import { HomeIndex } from "./features/home/HomeIndex"
 
 export function App(): JSX.Element {
   return (
@@ -48,6 +49,7 @@ export function App(): JSX.Element {
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Root/>}>
+            <Route index element={<HomeIndex/>}/>
             <Route path="request" element={<Outlet/>}>
               <Route index element={<RequestPage/>}/>
               <Route path=":eventId" element={<RequestPage/>}>

--- a/src/features/home/HomeAppBar.tsx
+++ b/src/features/home/HomeAppBar.tsx
@@ -30,6 +30,7 @@ import { HomeTab, HomeTabs } from "./HomeLogic"
 import { useContext } from "react"
 import { HomeContext } from "./HomeContext"
 import { useObservableState } from "observable-hooks"
+import { RequestContext } from "../request/RequestContext"
 
 export function HomeAppBar(): JSX.Element {
   const homeLogic = useContext(HomeContext)
@@ -49,9 +50,13 @@ export function HomeAppBar(): JSX.Element {
 
 
 function AppTabs( { tab }: { tab: HomeTab }): JSX.Element {
+  const requestLogic = useContext(RequestContext)
+  const currentEventId = useObservableState(requestLogic.currentEventId$)
+  const requestLink = "/request/" + (currentEventId ?? "")
+  
   return (
     <Tabs value={tab}>
-      <Tab value={HomeTabs.Request} label="受付済み" icon={<List/>} to="/request" component={Link} />
+      <Tab value={HomeTabs.Request} label="受付済み" icon={<List/>} to={requestLink} component={Link} />
       <Tab value={HomeTabs.Session} label="動画検索" icon={<VideoLabel/>} to="/session" component={Link}/>
     </Tabs>
   )

--- a/src/features/home/HomeIndex.tsx
+++ b/src/features/home/HomeIndex.tsx
@@ -35,7 +35,7 @@ export function HomeIndex(): JSX.Element {
   useEffect(() => {
     const redirect = "/request/" + (currentEventId ?? "")
     navigate(redirect, { replace: true })
-  }, [requestLogic, navigate])
+  }, [currentEventId, navigate])
   
   return <></>
 }

--- a/src/features/home/HomeIndex.tsx
+++ b/src/features/home/HomeIndex.tsx
@@ -1,7 +1,7 @@
 //
-// RequestPage.tsx
+// HomeIndex.tsx
 //
-// Copyright (c) 2018-2022 Hironori Ichimiya <hiron@hironytic.com>
+// Copyright (c) 2022 Hironori Ichimiya <hiron@hironytic.com>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,40 +22,20 @@
 // THE SOFTWARE.
 //
 
-import { EventTabs } from "./EventTabs"
-import { RequestList } from "./RequestList"
 import { useContext, useEffect } from "react"
-import { RequestContext } from "./RequestContext"
-import { Outlet, useNavigate, useParams } from "react-router-dom"
-import { IRDETypes } from "../../utils/IRDE"
+import { RequestContext } from "../request/RequestContext"
+import { useNavigate } from "react-router-dom"
 import { useObservableState } from "observable-hooks"
 
-export function RequestPage(): JSX.Element {
+export function HomeIndex(): JSX.Element {
   const requestLogic = useContext(RequestContext)
-  const navigate = useNavigate()
-  const params = useParams()
-  const eventId = params["eventId"]
   const currentEventId = useObservableState(requestLogic.currentEventId$)
-  const allEvents = useObservableState(requestLogic.allEvents$, [])
-  const requestListIRDE = useObservableState(requestLogic.requestList$, { type: IRDETypes.Initial })
+  const navigate = useNavigate()
 
   useEffect(() => {
-    if (currentEventId !== undefined && eventId === undefined) {
-      navigate("/request/" + currentEventId, { replace: true })
-    } else if (eventId !== undefined) {
-      requestLogic.setCurrentEventId(eventId)
-    }
-  }, [requestLogic, currentEventId, eventId, navigate])
-
-  const onCurrentIdChanged = (currentId: string | false) => {
-    navigate("/request/" + ((currentId !== false) ? currentId : ""))
-  }
-
-  return (
-    <>
-      <EventTabs events={allEvents} currentId={eventId ?? false} onCurrentIdChanged={onCurrentIdChanged} />
-      <RequestList requestList={requestListIRDE}/>
-      <Outlet/>
-    </>
-  )
+    const redirect = "/request/" + (currentEventId ?? "")
+    navigate(redirect, { replace: true })
+  }, [requestLogic, navigate])
+  
+  return <></>
 }

--- a/src/features/request/RequestLogic.test.ts
+++ b/src/features/request/RequestLogic.test.ts
@@ -186,12 +186,31 @@ describe("getAllEvents$", () => {
   })
 })
 
-describe("currentEventId", () => {
-  it("holds current event id", () => {
+describe("currentEventId$", () => {
+  it("holds current event id", async () => {
     const logic = createLogic()
-    
+
+    const observer = new EventuallyObserver<string | undefined>()
+    const expectation = observer.expectValue(eventId => {
+      expect(eventId).toBe("e3")
+    })
+    subscription.add(logic.currentEventId$.subscribe(observer))
+
     logic.setCurrentEventId("e3")
-    expect(logic.currentEventId).toBe("e3")
+    await expectation
+  })
+  
+  it("should automatically set current event to latest one", async () => {
+    mockRequestRepository.getAllEvents$.mockReturnValue(NEVER.pipe(startWith(eventData1)))
+    const logic = createLogic()
+
+    const observer = new EventuallyObserver<string | undefined>()
+    const expectation = observer.expectValue(eventId => {
+      expect(eventId).toBe("e1")
+    })
+    subscription.add(logic.currentEventId$.subscribe(observer))
+    
+    await expectation
   })
 })
 


### PR DESCRIPTION
- The latest event is now initially selected in request page.
- When user access to `/` or `/request`, it automatically redirect to current (selected) request page.
- Request tab in AppBar links to directly current request page.