### PR TITLE
Remove title in app bar

### DIFF
--- a/src/features/home/HomeAppBar.tsx
+++ b/src/features/home/HomeAppBar.tsx
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 //
 
-import { Tab, Tabs, Toolbar, Typography } from "@mui/material"
+import { Tab, Tabs, Toolbar } from "@mui/material"
 import { List, VideoLabel } from "@mui/icons-material"
 import { Link } from "react-router-dom"
 import { AppBar } from "../../utils/AppBar"
@@ -40,7 +40,6 @@ export function HomeAppBar(): JSX.Element {
   return (
     <AppBar position="sticky">
       <Toolbar>
-        <Typography variant="h6">カンファレンス動画鑑賞会</Typography>
         <div style={{ flexGrow: 1 }} />
         <AppTabs tab={isInMaintenance ? false : tab}/>
       </Toolbar>


### PR DESCRIPTION
Remove title in app bar because it is noisy especially on smartphones.

| BEFORE | AFTER |
----|---- 
| <img src="https://user-images.githubusercontent.com/1498691/190598863-c0140dcf-c76d-46b1-baba-180434c10d1d.png" width="300"> | <img src="https://user-images.githubusercontent.com/1498691/190598911-cd49178c-35b4-413b-ab2b-2479bd9abe9f.png" width="300"> |
