### PR TITLE
Search sessions in reverse chronological order

### DIFF
--- a/src/Firestore.ts
+++ b/src/Firestore.ts
@@ -152,7 +152,7 @@ export class Firestore {
       docQuery = query(docQuery, where("minutes", "==", filter.minutes))
     }
     docQuery = query(docQuery,
-      orderBy("starts", "asc"),
+      orderBy("starts", "desc"),
       limit(LIMIT),
     )
     return await filterSessions(docQuery)


### PR DESCRIPTION
Change search order to make it easier to find new sessions.
Note: this requires a change in the firestore indexes.

```diff
 {
   "indexes": [
     {
       "collectionGroup": "sessions",
       "queryScope": "COLLECTION",
       "fields": [
         {
           "fieldPath": "watched",
           "order": "ASCENDING"
         },
         {
           "fieldPath": "starts",
-          "order": "ASCENDING"
+          "order": "DESCENDING"
         }
       ]
     },
     {
       "collectionGroup": "sessions",
       "queryScope": "COLLECTION",
       "fields": [
         {
           "fieldPath": "minutes",
           "order": "ASCENDING"
         },
         {
           "fieldPath": "starts",
-          "order": "ASCENDING"
+          "order": "DESCENDING"
         }
       ]
     },
     {
       "collectionGroup": "sessions",
       "queryScope": "COLLECTION",
       "fields": [
         {
           "fieldPath": "conferenceId",
           "order": "ASCENDING"
         },
         {
           "fieldPath": "starts",
-          "order": "ASCENDING"
+          "order": "DESCENDING"
         }
       ]
     }
   ]
 }
```