### PR TITLE
Admin menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,8 @@ import { useObservableState } from "observable-hooks"
 import { CssBaseline } from "@mui/material"
 import { Maintenance } from "./features/home/Maintenance"
 import { HomeIndex } from "./features/home/HomeIndex"
+import { SignInPage } from "./features/sign_in/SignInPage"
+import { SignInProvider } from "./features/sign_in/SignInProvider"
 
 export function App(): JSX.Element {
   return (
@@ -60,6 +62,7 @@ export function App(): JSX.Element {
               <Route index element={<SessionPage/>}/>
               <Route path=":sessionId" element={<SessionDetail/>}/>
             </Route>
+            <Route path="signin" element={<SignIn/>}/>
             <Route path="*" element={<></>} />
           </Route>
         </Routes>
@@ -112,5 +115,13 @@ function SessionDetail(): JSX.Element {
     <SessionDetailProvider>
       <SessionDetailPage/>
     </SessionDetailProvider>
+  )
+}
+
+function SignIn(): JSX.Element {
+  return (
+    <SignInProvider>
+      <SignInPage/>
+    </SignInProvider>
   )
 }

--- a/src/Firebase.ts
+++ b/src/Firebase.ts
@@ -23,8 +23,9 @@
 //
 
 import { FirebaseApp, initializeApp } from 'firebase/app'
+import { Auth, getAuth as getAuthFromApp } from 'firebase/auth'
 import { Firestore, getFirestore as getFireStoreFromApp } from 'firebase/firestore'
-import { getFunctions as getFunctionsFromApp, Functions, httpsCallable } from 'firebase/functions'
+import { Functions, getFunctions as getFunctionsFromApp, httpsCallable } from 'firebase/functions'
 import { from, Observable, switchMap } from "rxjs"
 import { HttpsCallable } from "@firebase/functions"
 
@@ -63,4 +64,14 @@ export async function getFunctions(): Promise<Functions> {
 
 export async function getFunction<RequestData = unknown, ResponseData = unknown>(name: string): Promise<HttpsCallable<RequestData, ResponseData>> {
   return httpsCallable<RequestData, ResponseData>(await getFunctions(), name)
+}
+
+export async function getAuth(): Promise<Auth> {
+  return getAuthFromApp(await getFirebaseApp())
+}
+
+export function withAuth<T>(builder: (auth: Auth) => Observable<T>): Observable<T> {
+  return from(getAuth()).pipe(
+    switchMap(auth => builder(auth))
+  )
 }

--- a/src/FirebaseAuth.ts
+++ b/src/FirebaseAuth.ts
@@ -1,0 +1,41 @@
+//
+// FirebaseAuth.ts
+//
+// Copyright (c) 2023 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import { Observable, shareReplay } from "rxjs"
+import { onAuthStateChanged, User } from "firebase/auth"
+import { withAuth } from "./Firebase"
+
+export class FirebaseAuth {
+  static getCurrentUser$(): Observable<User | undefined> {
+    return withAuth(auth => {
+      return new Observable<User | undefined>(subscriber => {
+        return onAuthStateChanged(auth, user => {
+          subscriber.next(user ?? undefined)
+        })
+      }).pipe(
+        shareReplay(1),
+      )
+    })
+  }
+}

--- a/src/FirebaseAuth.ts
+++ b/src/FirebaseAuth.ts
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 //
 
-import { map, Observable, of, shareReplay, startWith, switchMap, tap } from "rxjs"
+import { map, Observable, of, shareReplay, startWith, switchMap } from "rxjs"
 import { onAuthStateChanged, User } from "firebase/auth"
 import { withAuth, withFirestore } from "./Firebase"
 import { collection, doc, DocumentSnapshot, onSnapshot } from "firebase/firestore"

--- a/src/features/request_detail/RequestDetailDialog.tsx
+++ b/src/features/request_detail/RequestDetailDialog.tsx
@@ -98,6 +98,8 @@ interface RequestDetailDoneBodyProps {
   requestDetail: RequestDetail
 }
 function RequestDetailDoneBody({ requestDetail }: RequestDetailDoneBodyProps): JSX.Element {
+  const logic = useContext(RequestDetailContext)
+  const isAdmin = useObservableState(logic.isAdmin$, false)
   return (
     <Grid container={true} spacing={2} justifyContent="space-between">
       <Grid item={true} xs={12}>
@@ -140,6 +142,16 @@ function RequestDetailDoneBody({ requestDetail }: RequestDetailDoneBodyProps): J
           )}
           <Grid item={true} style={{flexGrow: 1}}>
             <Grid container={true} spacing={0} alignItems="center" justifyContent="flex-end">
+              <Grid item={true}>
+                {isAdmin && (
+                  <Button onClick={() => void logic.makeItWatched()}>視聴済みにする</Button>
+                )}
+              </Grid>
+              <Grid item={true}>
+                {isAdmin && (
+                  <Button onClick={() => void logic.makeItUnwatched()}>未試聴にする</Button>
+                )}
+              </Grid>
               <Grid item={true}>
                 {requestDetail.videoUrl !== undefined && (
                   <TweetButton url={requestDetail.videoUrl} hashtags={["mobconfvideo"]}/>

--- a/src/features/request_detail/RequestDetailDialog.tsx
+++ b/src/features/request_detail/RequestDetailDialog.tsx
@@ -22,18 +22,18 @@
 // THE SOFTWARE.
 //
 
-import { Button, CircularProgress, Dialog, DialogContent, Grid, Typography } from "@mui/material"
-import { Note, OndemandVideo } from "@mui/icons-material"
+import { Button, CircularProgress, Dialog, DialogContent, Grid, Menu, MenuItem, Typography } from "@mui/material"
+import { Note, OndemandVideo, VerifiedUser } from "@mui/icons-material"
 import { IRDETypes } from "../../utils/IRDE"
 import { RequestDetail } from "./RequestDetailLogic"
 import { useNavigate, useParams } from "react-router-dom"
 import { WatchedEvents } from "../session_detail/WatchedEvents"
 import { Description } from "../session_detail/Description"
 import { Speakers } from "../session_detail/Speakers"
-import { useContext, useEffect } from "react"
+import { useContext, useEffect, useState, MouseEvent } from "react"
 import { RequestDetailContext } from "./RequestDetailContext"
 import { useObservableState } from "observable-hooks"
-import { TweetButton } from "../../utils/TweetButton"
+import { createTweetUrl, TweetButton } from "../../utils/TweetButton"
 
 export function RequestDetailDialog(): JSX.Element {
   const navigate = useNavigate()
@@ -99,7 +99,43 @@ interface RequestDetailDoneBodyProps {
 }
 function RequestDetailDoneBody({ requestDetail }: RequestDetailDoneBodyProps): JSX.Element {
   const logic = useContext(RequestDetailContext)
+  const isWatched = useObservableState(logic.isWatched$, undefined)
   const isAdmin = useObservableState(logic.isAdmin$, false)
+
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  function handleShowAdminMenu(event: MouseEvent<HTMLButtonElement>) {
+    setAnchorEl(event.currentTarget)
+  }
+  function handleCloseAdminMenu() {
+    setAnchorEl(null)
+  }
+  function handleMakeItWatched() {
+    logic.makeItWatched()
+    handleCloseAdminMenu()
+  }
+  function handleMakeItUnwatched() {
+    logic.makeItUnwatched()
+    handleCloseAdminMenu()
+  }
+  function handleAnnounceTweet1() {
+    const announceTweetUrl1 = createTweetUrl({
+      text: `${requestDetail.conference}から「${requestDetail.title}」`,
+      url: requestDetail.videoUrl,
+      hashtags: ["mobconfvideo"],
+    })
+    window.open(announceTweetUrl1, "_blank", "noopener,noreferrer")
+  }
+  function handleAnnounceTweet2() {
+    if (requestDetail.slideUrl !== undefined) {
+      const announceTweetUrl2 = createTweetUrl({
+        text: "この動画のスライドはこちらです。",
+        url: requestDetail.slideUrl,
+        hashtags: ["mobconfvideo"],
+      })
+      window.open(announceTweetUrl2, "_blank", "noopener,noreferrer")
+    }
+  }
+  
   return (
     <Grid container={true} spacing={2} justifyContent="space-between">
       <Grid item={true} xs={12}>
@@ -144,12 +180,23 @@ function RequestDetailDoneBody({ requestDetail }: RequestDetailDoneBodyProps): J
             <Grid container={true} spacing={0} alignItems="center" justifyContent="flex-end">
               <Grid item={true}>
                 {isAdmin && (
-                  <Button onClick={() => void logic.makeItWatched()}>視聴済みにする</Button>
-                )}
-              </Grid>
-              <Grid item={true}>
-                {isAdmin && (
-                  <Button onClick={() => void logic.makeItUnwatched()}>未試聴にする</Button>
+                  <>
+                    <Button onClick={handleShowAdminMenu}>
+                      <VerifiedUser/> 運営メニュー
+                    </Button>
+                    <Menu open={anchorEl !== null} anchorEl={anchorEl} onClose={handleCloseAdminMenu}>
+                      <MenuItem onClick={() => void handleAnnounceTweet1()}>開始ツイート1</MenuItem>
+                      {requestDetail.slideUrl !== undefined && (
+                        <MenuItem onClick={() => void handleAnnounceTweet2()}>開始ツイート2</MenuItem>
+                      )}
+                      {isWatched !== true && (
+                        <MenuItem onClick={() => void handleMakeItWatched()}>鑑賞済みにする</MenuItem>
+                      )}
+                      {isWatched !== false && (
+                        <MenuItem onClick={() => void handleMakeItUnwatched()}>未鑑賞に戻す</MenuItem>
+                      )}
+                    </Menu>
+                  </>
                 )}
               </Grid>
               <Grid item={true}>

--- a/src/features/request_detail/RequestDetailLogic.test.ts
+++ b/src/features/request_detail/RequestDetailLogic.test.ts
@@ -85,6 +85,8 @@ class MockRequestDetailRepository implements RequestDetailRepository {
   getSession$ = jest.fn((_sessionId: string) => NEVER.pipe(startWith(session1)))
   getAllEvents$ = jest.fn(() => NEVER.pipe(startWith(eventList1)))
   getConferenceName$ = jest.fn((_conferenceId: string) => NEVER.pipe(startWith(conferenceName1)))
+  isAdmin$ = jest.fn(() => NEVER.pipe(startWith(false)))
+  updateRequestWatched = jest.fn((_eventId: string, _requestId: string, _value: boolean) => {})
 }
 
 let mockRequestDetailRepository: MockRequestDetailRepository

--- a/src/features/request_detail/RequestDetailLogic.ts
+++ b/src/features/request_detail/RequestDetailLogic.ts
@@ -54,6 +54,7 @@ export interface RequestDetailLogic extends Logic {
   makeItWatched(): void
   makeItUnwatched(): void
   
+  isWatched$: Observable<boolean | undefined>
   requestDetail$: Observable<RequestDetailIRDE>
   isAdmin$: Observable<boolean>
 }
@@ -65,11 +66,13 @@ export class NullRequestDetailLogic implements RequestDetailLogic {
   makeItWatched(): void {}
   makeItUnwatched(): void {}
 
+  isWatched$ = NEVER
   requestDetail$ = NEVER
   isAdmin$ = NEVER
 }
 
 export class AppRequestDetailLogic implements RequestDetailLogic {
+  isWatched$ = new BehaviorSubject<boolean | undefined>(undefined)
   requestDetail$ = new BehaviorSubject<RequestDetailIRDE>({ type: IRDETypes.Initial })
   
   constructor(private readonly repository: RequestDetailRepository) {
@@ -125,6 +128,7 @@ export class AppRequestDetailLogic implements RequestDetailLogic {
       {
         next: (request) => {
           this.latestRequest = request
+          this.isWatched$.next(request.isWatched)
           if (request.sessionId !== this.latestSessionId) {
             this.subscribeSession(request.sessionId)
           } else {

--- a/src/features/request_detail/RequestDetailLogic.ts
+++ b/src/features/request_detail/RequestDetailLogic.ts
@@ -51,15 +51,22 @@ export type RequestDetailIRDE = IRDE<RequestDetailIProps, RequestDetailRProps, R
 
 export interface RequestDetailLogic extends Logic {
   setCurrentRequest(eventId: string, requestId: string): void
+  makeItWatched(): void
+  makeItUnwatched(): void
   
   requestDetail$: Observable<RequestDetailIRDE>
+  isAdmin$: Observable<boolean>
 }
 
 export class NullRequestDetailLogic implements RequestDetailLogic {
   dispose() {}
   setCurrentRequest(eventId: string, requestId: string): void {}
 
+  makeItWatched(): void {}
+  makeItUnwatched(): void {}
+
   requestDetail$ = NEVER
+  isAdmin$ = NEVER
 }
 
 export class AppRequestDetailLogic implements RequestDetailLogic {
@@ -252,5 +259,21 @@ export class AppRequestDetailLogic implements RequestDetailLogic {
     this.requestSubscription?.unsubscribe()
     this.sessionSubscription?.unsubscribe()
     this.conferenceSubscription?.unsubscribe()
+  }
+
+  get isAdmin$(): Observable<boolean> {
+    return this.repository.isAdmin$()
+  }
+
+  makeItWatched() {
+    if (this.latestEventId !== undefined && this.latestRequestId !== undefined) {
+      this.repository.updateRequestWatched(this.latestEventId, this.latestRequestId, true)
+    }
+  }
+  
+  makeItUnwatched() {
+    if (this.latestEventId !== undefined && this.latestRequestId !== undefined) {
+      this.repository.updateRequestWatched(this.latestEventId, this.latestRequestId, false)
+    }
   }
 }

--- a/src/features/sign_in/SignInContext.ts
+++ b/src/features/sign_in/SignInContext.ts
@@ -1,0 +1,28 @@
+//
+// SignInContext.ts
+//
+// Copyright (c) 2023 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import { NullSignInLogic, SignInLogic } from "./SignInLogic"
+import React from "react"
+
+export const SignInContext = React.createContext<SignInLogic>(new NullSignInLogic())

--- a/src/features/sign_in/SignInLogic.ts
+++ b/src/features/sign_in/SignInLogic.ts
@@ -1,0 +1,73 @@
+//
+// SignInLogic.ts
+//
+// Copyright (c) 2023 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import { Logic } from "../../utils/LogicProvider"
+import { SignInRepository } from "./SignInRepository"
+import { NEVER, Observable } from "rxjs"
+import { runDetached } from "../../utils/RunDetached"
+
+export interface SignInLogic extends Logic {
+  isAuthenticated$: Observable<boolean>
+  // isLinkedToGoogle$: Observable<boolean>
+  
+  signOut(): void
+  signInWithGoogle(): void
+}
+
+export class NullSignInLogic implements SignInLogic {
+  dispose() {}
+  get isAuthenticated$(): Observable<boolean> { return NEVER }
+  // get isLinkedToGoogle$(): Observable<boolean> { return NEVER }
+  signOut() {}
+  signInWithGoogle() {}
+}
+
+export class AppSignInLogic implements SignInLogic {
+  constructor(private readonly repository: SignInRepository) {
+  }
+  
+  dispose() {
+  }
+  
+  get isAuthenticated$(): Observable<boolean> {
+    return this.repository.isAuthenticated$()
+  }
+  
+  // get isLinkedToGoogle$(): Observable<boolean> {
+  //   return this.repository.isLinkedToGoogle$()
+  // }
+  
+  signOut() {
+    runDetached(async () => {
+      await this.repository.signOut()
+    })
+  }
+
+  signInWithGoogle() {
+    runDetached(async () => {
+      // TODO: Error handling.
+      await this.repository.signInWithGoogle()
+    })
+  }
+}

--- a/src/features/sign_in/SignInPage.tsx
+++ b/src/features/sign_in/SignInPage.tsx
@@ -1,0 +1,77 @@
+//
+// SignInPage.tsx
+//
+// Copyright (c) 2023 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import { Box, Button, Typography } from "@mui/material"
+import { useContext } from "react"
+import { SignInContext } from "./SignInContext"
+import { useObservableState } from "observable-hooks"
+
+export function SignInPage(): JSX.Element {
+  const logic = useContext(SignInContext)
+  const isAuthenticated = useObservableState(logic.isAuthenticated$, false)
+  
+  return (
+    <Box sx={{ p: 2 }}>
+      <Box sx={{ textAlign: "center" }}>
+        {(isAuthenticated) ? <Authenticated/> : <Unauthenticated/>}
+      </Box>
+    </Box>
+  )
+}
+
+function Authenticated(): JSX.Element {
+  const logic = useContext(SignInContext)
+  return (
+    <>
+      <Typography>認証済み</Typography>
+      <Button variant="contained" onClick={() => void logic.signOut() }>サインアウト</Button>
+    </>
+  )
+}
+
+function Unauthenticated(): JSX.Element {
+  const logic = useContext(SignInContext)
+  return (
+    <>
+      <Button variant="contained" onClick={() => void logic.signInWithGoogle() }>Googleでサインイン</Button>
+    </>
+  )
+}
+
+// function SignInWithGoogle(): JSX.Element {
+//   const logic = useContext(SignInContext)
+//   const isSignInButtonVisible = useObservableState(logic.isSignInWithGoogleButtonVisible$, false)
+//   const isSignOutButtonVisible = useObservableState(logic.isSignOutOfGoogleButtonVisible$, false)
+//  
+//   return (
+//     <>
+//       {(isSignInButtonVisible) && (
+//         <Button variant="contained" onClick={() => void logic.signInWithGoogle() }>Googleでサインイン</Button>
+//       )}
+//       {(isSignOutButtonVisible) && (
+//         <Button variant="contained">Googleとの連携を解除</Button>
+//       )}
+//     </>
+//   )
+// }

--- a/src/features/sign_in/SignInProvider.tsx
+++ b/src/features/sign_in/SignInProvider.tsx
@@ -1,0 +1,37 @@
+//
+// SignInProvider.tsx
+//
+// Copyright (c) 2023 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import { ProviderProps } from "../../utils/ProviderProps"
+import { LogicProvider } from "../../utils/LogicProvider"
+import { SignInContext } from "./SignInContext"
+import { AppSignInLogic } from "./SignInLogic"
+import { FirebaseSignInRepository } from "./SignInRepository"
+
+export function SignInProvider({ children }: ProviderProps): JSX.Element {
+  return (
+    <LogicProvider context={SignInContext} creator={() => new AppSignInLogic(new FirebaseSignInRepository())}>
+      {children}
+    </LogicProvider>
+  )
+}

--- a/src/features/sign_in/SignInRepository.ts
+++ b/src/features/sign_in/SignInRepository.ts
@@ -1,0 +1,63 @@
+//
+// SignInRepository.ts
+//
+// Copyright (c) 2023 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import { map, Observable } from "rxjs"
+import { FirebaseAuth } from "../../FirebaseAuth"
+import { signInWithPopup, GoogleAuthProvider } from "firebase/auth"
+import { getAuth } from "../../Firebase"
+
+export interface SignInRepository {
+  isAuthenticated$(): Observable<boolean>
+  // isLinkedToGoogle$(): Observable<boolean>
+  signOut(): Promise<void>
+  signInWithGoogle(): Promise<void>
+}
+
+export class FirebaseSignInRepository implements SignInRepository{
+  isAuthenticated$(): Observable<boolean> {
+    return FirebaseAuth.getCurrentUser$().pipe(
+      map(user => user !== undefined)
+    )
+  }
+  
+  // isLinkedToGoogle$(): Observable<boolean> {
+  //   return FirebaseAuth.getCurrentUser$().pipe(
+  //     map(user => {
+  //       if (user === undefined) { return false }
+  //       return user.providerData.find(userInfo => userInfo.providerId === GoogleAuthProvider.PROVIDER_ID) !== undefined 
+  //     })
+  //   )
+  // }
+
+  async signOut(): Promise<void> {
+    const auth = await getAuth()
+    await auth.signOut()
+  }
+  
+  async signInWithGoogle(): Promise<void> {
+    const auth = await getAuth()
+    const provider = new GoogleAuthProvider()
+    await signInWithPopup(auth, provider)
+  }
+}

--- a/src/utils/TweetButton.tsx
+++ b/src/utils/TweetButton.tsx
@@ -31,18 +31,22 @@ interface TweetButtonProps {
   hashtags?: string[]
 }
 
-export function TweetButton({ text, url, hashtags }: TweetButtonProps): JSX.Element {
+export function createTweetUrl({ text, url, hashtags }: TweetButtonProps): string {
   const tweetUrl = new URL("https://twitter.com/intent/tweet")
   if (hashtags !== undefined && hashtags.length > 0) {
     tweetUrl.searchParams.set("hashtags", hashtags.join(","))
   }
   if (text !== undefined) {
-    tweetUrl.searchParams.set("text", text)  
+    tweetUrl.searchParams.set("text", text)
   }
   if (url !== undefined) {
     tweetUrl.searchParams.set("url", url)
   }
-  const tweetUrlString = tweetUrl.toString()
+  return tweetUrl.toString()
+}
+
+export function TweetButton(props: TweetButtonProps): JSX.Element {
+  const tweetUrlString = createTweetUrl(props)
   
   return (
     <Button href={tweetUrlString} target="_blank" rel="noopener noreferrer" color="primary">


### PR DESCRIPTION
Implement functions for MobConfVideo event stuff.

This needs:
- Turn on Google provider at Firebase Authentication
- Update Firebase Cloud Firestore rules to allow authenticated stuff to change request status

With this PR, you can sign in at `/signin` page. Currently only "Sign in with Google" is available.
The page is not linked from anywhare.

If you have signed in with authenticated stuff account (that uid is included in Firestore config documents), you see "運営メニュー" (Operator Menu) on requested event.
WIth this menu, you can:

- Tweet message which announce currently watching video.
- Change request status to watched or unwatched.
