### PR TITLE
Update dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,15 +7,24 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "friday"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    groups:
+      semver-patch:
+        update-types:
+          - "patch"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
   
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "friday"
     labels:
       - "dependencies"


### PR DESCRIPTION
Defines dependabot groups below:

- `semver-patch`: contains patch level updates.
- `typescript-eslint`: contains `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin`.

Also change schedule.interval to weekly.