### PR TITLE
Configure ESM build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "mob_conf_video_web",
   "version": "2.1.0",
   "private": true,
+  "type": "module",
   "dependencies": {
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",


### PR DESCRIPTION
As below text was shown in the console when I started the Vite server, I configured to use the ESM build of Vite according to that guide.

```
The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
```
