### PR TITLE
Bug: #379 Fix "Finished" dialog is not closed immediately

### DIFF
--- a/src/features/request_submission/RequestSubmissionLogic.ts
+++ b/src/features/request_submission/RequestSubmissionLogic.ts
@@ -135,7 +135,7 @@ export class AppRequestSubmissionLogic implements RequestSubmissionLogic {
           }
         }
         tryCount++
-        if (tryCount >= 3) {
+        if (tryAgain && tryCount >= 3) {
           // forbid user to try another request code repeatably
           await delay(5000)
           tryCount = 0


### PR DESCRIPTION
fix #379 

Fixed a bug where a 5-second delay occurred even on successful request submission.

There is an intentional 5-second delay which occurs every 3 times an invalid request keys is entered to avoid excessive attacks. But it happens unintentionally when the user is entered a valid key for the third time.