### PR TITLE
feat: add delete request feature to admin menu

### DIFF
--- a/src/features/request_detail/RequestDetailDialog.tsx
+++ b/src/features/request_detail/RequestDetailDialog.tsx
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 //
 
-import { Button, CircularProgress, Dialog, DialogContent, Grid, Menu, MenuItem, Typography } from "@mui/material"
+import { Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Grid, Menu, MenuItem, Typography } from "@mui/material"
 import { Note, OndemandVideo, VerifiedUser } from "@mui/icons-material"
 import { IRDETypes } from "../../utils/IRDE"
 import { RequestDetail } from "./RequestDetailLogic"
@@ -98,11 +98,14 @@ interface RequestDetailDoneBodyProps {
   requestDetail: RequestDetail
 }
 function RequestDetailDoneBody({ requestDetail }: RequestDetailDoneBodyProps): React.JSX.Element {
+  const navigate = useNavigate()
   const logic = useContext(RequestDetailContext)
   const isWatched = useObservableState(logic.isWatched$, undefined)
   const isAdmin = useObservableState(logic.isAdmin$, false)
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
+
   function handleShowAdminMenu(event: MouseEvent<HTMLButtonElement>) {
     setAnchorEl(event.currentTarget)
   }
@@ -116,6 +119,17 @@ function RequestDetailDoneBody({ requestDetail }: RequestDetailDoneBodyProps): R
   function handleMakeItUnwatched() {
     logic.makeItUnwatched()
     handleCloseAdminMenu()
+  }
+  function handleDeleteRequest() {
+    setDeleteConfirmOpen(true)
+    handleCloseAdminMenu()
+  }
+  function handleConfirmDelete() {
+    logic.deleteRequest()
+    navigate("..", { replace: true })
+  }
+  function handleCancelDelete() {
+    setDeleteConfirmOpen(false)
   }
   function handleAnnounceTweet1() {
     const announceTweetUrl1 = createTweetUrl({
@@ -211,7 +225,20 @@ function RequestDetailDoneBody({ requestDetail }: RequestDetailDoneBodyProps): R
                       {isWatched !== false && (
                         <MenuItem onClick={() => void handleMakeItUnwatched()}>未鑑賞に戻す</MenuItem>
                       )}
+                      <MenuItem onClick={handleDeleteRequest}>削除</MenuItem>
                     </Menu>
+                    <Dialog open={deleteConfirmOpen} onClose={handleCancelDelete}>
+                      <DialogTitle>リクエストの削除</DialogTitle>
+                      <DialogContent>
+                        <DialogContentText>
+                          このリクエストを削除します。よろしいですか？
+                        </DialogContentText>
+                      </DialogContent>
+                      <DialogActions>
+                        <Button onClick={handleCancelDelete}>キャンセル</Button>
+                        <Button onClick={handleConfirmDelete} color="error">削除する</Button>
+                      </DialogActions>
+                    </Dialog>
                   </>
                 )}
               </Grid>

--- a/src/features/request_detail/RequestDetailLogic.test.ts
+++ b/src/features/request_detail/RequestDetailLogic.test.ts
@@ -88,6 +88,7 @@ class MockRequestDetailRepository implements RequestDetailRepository {
   getConferenceName$ = vi.fn((_conferenceId: string) => NEVER.pipe(startWith(conferenceName1)))
   isAdmin$ = vi.fn(() => NEVER.pipe(startWith(false)))
   updateRequestWatched = vi.fn((_eventId: string, _requestId: string, _value: boolean) => { /* do nothing */ })
+  deleteRequest = vi.fn((_eventId: string, _requestId: string) => { /* do nothing */ })
 }
 
 let mockRequestDetailRepository: MockRequestDetailRepository
@@ -249,5 +250,23 @@ describe("request detail", () => {
     await expectation
 
     expect(requestDetail.conference).toBe("")
+  })
+})
+
+describe("deleteRequest", () => {
+  it("should call repository.deleteRequest with current event and request id", async () => {
+    const logic = createLogic()
+
+    const observer = new EventuallyObserver<RequestDetailIRDE>()
+    const expectation = observer.expectValue(irde => {
+      expect(irde.type).toBe(IRDETypes.Done)
+    })
+    subscription.add(logic.requestDetail$.subscribe(observer))
+
+    logic.setCurrentRequest("e1", "r1")
+    await expectation
+
+    logic.deleteRequest()
+    expect(mockRequestDetailRepository.deleteRequest).toHaveBeenCalledWith("e1", "r1")
   })
 })

--- a/src/features/request_detail/RequestDetailLogic.ts
+++ b/src/features/request_detail/RequestDetailLogic.ts
@@ -53,6 +53,7 @@ export interface RequestDetailLogic extends Logic {
   setCurrentRequest(eventId: string, requestId: string): void
   makeItWatched(): void
   makeItUnwatched(): void
+  deleteRequest(): void
   
   isWatched$: Observable<boolean | undefined>
   requestDetail$: Observable<RequestDetailIRDE>
@@ -65,6 +66,7 @@ export class NullRequestDetailLogic implements RequestDetailLogic {
 
   makeItWatched(): void { /* do nothing */ }
   makeItUnwatched(): void { /* do nothing */ }
+  deleteRequest(): void { /* do nothing */ }
 
   isWatched$ = NEVER
   requestDetail$ = NEVER
@@ -274,10 +276,20 @@ export class AppRequestDetailLogic implements RequestDetailLogic {
       this.repository.updateRequestWatched(this.latestEventId, this.latestRequestId, true)
     }
   }
-  
+
   makeItUnwatched() {
     if (this.latestEventId !== undefined && this.latestRequestId !== undefined) {
       this.repository.updateRequestWatched(this.latestEventId, this.latestRequestId, false)
+    }
+  }
+
+  deleteRequest() {
+    if (this.latestEventId !== undefined && this.latestRequestId !== undefined) {
+      // Unsubscribe before deleting so that the deletion event from Firestore,
+      // which causes getRequest$ to throw because the document no longer exists, is not received.
+      this.requestSubscription?.unsubscribe()
+      this.requestSubscription = undefined
+      this.repository.deleteRequest(this.latestEventId, this.latestRequestId)
     }
   }
 }

--- a/src/features/request_detail/RequestDetailRepository.ts
+++ b/src/features/request_detail/RequestDetailRepository.ts
@@ -28,7 +28,7 @@ import { Session } from "../../entities/Session"
 import { Event } from "../../entities/Event"
 import { Firestore } from "../../Firestore"
 import { getFirestore } from "../../Firebase"
-import { runTransaction } from 'firebase/firestore'
+import { deleteDoc, runTransaction } from 'firebase/firestore'
 import { runDetached } from "../../utils/RunDetached"
 import { collection, doc } from "firebase/firestore"
 import * as FirebaseAuth from "../../FirebaseAuth"
@@ -40,6 +40,7 @@ export interface RequestDetailRepository {
   getConferenceName$(conferenceId: string): Observable<string>
   isAdmin$(): Observable<boolean>
   updateRequestWatched(eventId: string, requestId: string, value: boolean): void
+  deleteRequest(eventId: string, requestId: string): void
 }
 
 export class FirestoreRequestDetailRepository implements RequestDetailRepository {
@@ -74,6 +75,15 @@ export class FirestoreRequestDetailRepository implements RequestDetailRepository
           transaction.update(docRef, { watched: value })
         }
       })
+    })
+  }
+
+  deleteRequest(eventId: string, requestId: string): void {
+    runDetached(async () => {
+      const firestore = await getFirestore()
+      const collectionRef = collection(firestore, "events", eventId, "requests")
+      const docRef = doc(collectionRef, requestId)
+      await deleteDoc(docRef)
     })
   }
 }


### PR DESCRIPTION
## Summary

- Add a "Delete" menu item to the admin menu in RequestDetailDialog
- Show a confirmation dialog before deleting, then delete the request on confirmation
- Navigate back to the request list after deletion

## Changes

- `RequestDetailRepository`: Add `deleteRequest` method implemented with Firestore `deleteDoc`
- `RequestDetailLogic`: Add `deleteRequest()` to the interface, null implementation, and app implementation. Unsubscribe `requestSubscription` before executing the deletion to avoid receiving the "document not found" error event from Firestore
- `RequestDetailDialog`: Add "Delete" menu item and confirmation dialog to the admin menu
- `RequestDetailLogic.test.ts`: Add test case for `deleteRequest`

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)