### PR TITLE
Add supply chain protection (npm cooldown) and bump Node.js to 24.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     labels:
       - "dependencies"

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     ]
   },
   "volta": {
-    "node": "24.14.0"
+    "node": "24.16.0"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",


### PR DESCRIPTION
## Summary
- Add `.npmrc` with `ignore-scripts=true` and `min-release-age=7` to delay installing recently-published package versions, mitigating supply chain attacks (e.g. compromised package versions caught and yanked within the cooldown window)
- Add a matching `cooldown.default-days: 7` to the npm entry in `.github/dependabot.yml`
- Bump Node.js to 24.x (Volta `package.json` and CI `build_test.yml`), since `min-release-age` requires npm 11.10.0+, which is only bundled starting with Node 24.x (Node 20.x/22.x latest patches still ship npm 10.x)

## Test plan
- [x] `npm run check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (63/63)
- [x] `npm run build` succeeds
- [x] Verified `ignore-scripts=true` does not break the build (the only deps with postinstall scripts — `@firebase/util` and `protobufjs` — ship prebuilt fallback artifacts / harmless warnings)
- [x] Verified `min-release-age=7` resolves correctly via `npm config list` (`before = "2026-05-31T05:59:36.778Z"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)