### PR TITLE
ci: pin actions to SHA and drop node-version matrix

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,4 +1,4 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Build and Test
@@ -16,18 +16,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [24.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+    - name: Use Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
       with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
+        node-version-file: 'package.json'
     - run: npm ci
     - run: npm run check
     - run: npm run lint


### PR DESCRIPTION
## Summary
- Pin `actions/checkout` to SHA `df4cb1c069e1874edd31b4311f1884172cec0e10` (v6.0.3) and `actions/setup-node` to SHA `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (v6.4.0) for supply chain protection
- Drop the `node-version` matrix and use `node-version-file: 'package.json'` instead, so CI uses the same Volta-pinned Node version (`24.16.0`) declared in `package.json`
- Remove the now-unnecessary `cache: 'npm'` setup-node option

## Test plan
- [ ] Confirm the GitHub Actions workflow run succeeds on this PR