### PR TITLE
chore: Ignore .playwright-mcp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .env.test.local
 .env.production.local
 CLAUDE.local.md
+.playwright-mcp/
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
Add `.playwright-mcp` directory to .gitignore.
That directory is created by using Playwright MCP.